### PR TITLE
refactor(lobby): use FrozenValue for MatchRecord history

### DIFF
--- a/logic/crates/lobby/src/lib.rs
+++ b/logic/crates/lobby/src/lib.rs
@@ -6,7 +6,9 @@ use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::{Deserialize, Serialize};
 use calimero_sdk::types::Error as AppError;
 use calimero_storage::collections::crdt_meta::MergeError;
-use calimero_storage::collections::{Counter, LwwRegister, Mergeable, UnorderedMap, Vector};
+use calimero_storage::collections::{
+    Counter, FrozenValue, LwwRegister, Mergeable, UnorderedMap, Vector,
+};
 use calimero_storage::env as storage_env;
 use calimero_storage_macros::Mergeable;
 
@@ -124,17 +126,9 @@ pub struct MatchRecord {
     pub finished_ms: u64,
 }
 
-impl Mergeable for MatchRecord {
-    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
-        // History records are append-only and immutable per match, so any two
-        // replicas agreeing on `match_id` already agree on the rest. Use the
-        // later `finished_ms` as a deterministic tiebreaker just in case.
-        if other.finished_ms > self.finished_ms {
-            *self = other.clone();
-        }
-        Ok(())
-    }
-}
+// MatchRecord is append-once / immutable per match — it's stored as
+// `FrozenValue<MatchRecord>` inside `history`, which supplies a no-op
+// `Mergeable` impl for free. No hand-rolled merge to own.
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -161,7 +155,7 @@ pub struct LobbyState {
     created_ms: LwwRegister<u64>,
     matches: UnorderedMap<String, MatchSummary>,
     player_stats: UnorderedMap<String, PlayerStats>,
-    history: Vector<MatchRecord>,
+    history: Vector<FrozenValue<MatchRecord>>,
 }
 
 #[app::logic]
@@ -302,7 +296,7 @@ impl LobbyState {
             .history
             .iter()
             .map_err(|e| AppError::msg(format!("history.iter: {e}")))?;
-        Ok(iter.collect())
+        Ok(iter.map(|f| f.0).collect())
     }
 
     pub fn on_match_finished(
@@ -341,12 +335,12 @@ impl LobbyState {
             .map_err(|e| GameError::Invalid(format!("matches.insert failed: {e}")))?;
 
         self.history
-            .push(MatchRecord {
+            .push(FrozenValue::from(MatchRecord {
                 match_id: match_id.to_string(),
                 winner: winner.to_string(),
                 loser: loser.to_string(),
                 finished_ms,
-            })
+            }))
             .map_err(|e| GameError::Invalid(format!("history.push failed: {e}")))?;
 
         bump_stats(&mut self.player_stats, winner, true)?;
@@ -570,12 +564,13 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // CRDT merge tests (review point 6).
+    // CRDT merge tests.
     //
-    // These exercise the hand-rolled `Mergeable` impls on `MatchSummary`
-    // and `MatchRecord` directly — the place the rank-clobber bug lived.
-    // Every hand-written merge is a correctness burden; these tests pin
-    // its current contract so future edits can't silently break it.
+    // These exercise the hand-rolled `Mergeable` impl on `MatchSummary` —
+    // the last remaining place we own the lattice-correctness proof
+    // ourselves. `MatchRecord` is now `FrozenValue<MatchRecord>` in the
+    // history vector, so its merge is an SDK-provided no-op (no tests
+    // needed — frozen values cannot disagree by construction).
     //
     // What we explicitly do NOT cover here (would need a multi-actor
     // test harness, not yet exposed by Calimero for unit tests):
@@ -683,36 +678,4 @@ mod tests {
         // The two outcomes disagree → not commutative. Acknowledged.
     }
 
-    #[test]
-    fn merge_match_record_keeps_later_finished_ms() {
-        let mut a = MatchRecord {
-            match_id: "m-1".into(),
-            winner: "p1".into(),
-            loser: "p2".into(),
-            finished_ms: 100,
-        };
-        let b = MatchRecord {
-            match_id: "m-1".into(),
-            winner: "p1".into(),
-            loser: "p2".into(),
-            finished_ms: 200,
-        };
-        a.merge(&b).unwrap();
-        assert_eq!(a.finished_ms, 200);
-    }
-
-    #[test]
-    fn merge_match_record_is_idempotent() {
-        let a_orig = MatchRecord {
-            match_id: "m-1".into(),
-            winner: "p1".into(),
-            loser: "p2".into(),
-            finished_ms: 150,
-        };
-        let mut a = a_orig.clone();
-        a.merge(&a_orig).unwrap();
-        assert_eq!(a.finished_ms, 150);
-        assert_eq!(a.winner, "p1");
-        assert_eq!(a.loser, "p2");
-    }
 }

--- a/logic/crates/lobby/src/lib.rs
+++ b/logic/crates/lobby/src/lib.rs
@@ -677,5 +677,4 @@ mod tests {
         );
         // The two outcomes disagree → not commutative. Acknowledged.
     }
-
 }


### PR DESCRIPTION
## Summary

- Replace the hand-rolled `Mergeable` impl on `MatchRecord` with the SDK-provided `FrozenValue<MatchRecord>` wrapper. History records are append-once / immutable per match, so a no-op merge is the semantically correct choice — the previous *later-`finished_ms`-wins* tiebreaker only guarded against a case that cannot happen by construction.
- `LobbyState.history: Vector<MatchRecord>` → `Vector<FrozenValue<MatchRecord>>`, with the value wrapped on push and unwrapped on read.
- Delete the two `merge_match_record_*` unit tests that pinned the now-gone hand-rolled contract.

## Why this is safe

- **Wire format is byte-identical.** `FrozenValue<T>`'s `BorshSerialize` impl is transparent (see `calimero-storage/src/collections/frozen_value.rs:26-39`), so `logic/crates/lobby/res/abi.json` and `app/src/api/lobby/LobbyClient.ts`'s `MatchRecord` interface do not change.
- **The public API surface is unchanged.** `get_history()` still returns `Vec<MatchRecord>` — the `FrozenValue` wrapping is an internal storage detail.
- **The `MatchSummary` hand-rolled merge is intentionally left in place.** That one is a real design decision (status lattice + per-field CRDT decomposition + view type) and is tracked separately.

## Test plan

- [x] `cargo check -p battleships-lobby --target wasm32-unknown-unknown` — clean.
- [x] `cargo test -p battleships-lobby --lib` — 18/18 pass (down from 20; the 2 removed tests covered the deleted hand-rolled merge).
- [ ] Merobox e2e: `e2e/workflow-battleships-e2e.yml` — verifies the history vector still replicates correctly across nodes.
- [ ] Manual smoke: finish a match and confirm `get_history` returns the expected record shape to the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small internal refactor of CRDT merge behavior for match history; public API still returns `Vec<MatchRecord>` and changes are localized to lobby state/history handling.
> 
> **Overview**
> Refactors lobby match history storage to wrap `MatchRecord` in `FrozenValue`, removing the custom `Mergeable` implementation and relying on the SDK’s no-op merge for append-once/immutable history entries.
> 
> `LobbyState.history` is now `Vector<FrozenValue<MatchRecord>>`, with records wrapped on `push` and unwrapped in `get_history()`. The now-obsolete `MatchRecord` merge unit tests and related commentary were removed/updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47d3ddb810f4c7be1cfe9bd4607b5e2090e5a7ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->