### PR TITLE
feat(ci): Playwright browser integration tests against live merod nodes

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"57a1c982-c7a2-48c7-9725-d9169f518eb3","pid":49697,"procStart":"Fri May  8 13:22:22 2026","acquiredAt":1778328045431}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"57a1c982-c7a2-48c7-9725-d9169f518eb3","pid":49697,"procStart":"Fri May  8 13:22:22 2026","acquiredAt":1778328045431}

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -213,24 +213,39 @@ jobs:
           [ -n "$ACCESS_TOKEN_1" ] || { echo "Node 1 auth failed: $AUTH_1"; exit 1; }
           [ -n "$ACCESS_TOKEN_2" ] || { echo "Node 2 auth failed: $AUTH_2"; exit 1; }
 
-          APPS=$(curl -sf "${NODE_1_URL}/admin-api/applications" \
-            -H "Authorization: Bearer ${ACCESS_TOKEN_1}")
+          probe_admin() {
+            local node_url=$1
+            local path=$2
+            local token=$3
+            local code
+            local body
+            body=$(curl -sS -o /tmp/probe.body -w "%{http_code}" \
+              -H "Authorization: Bearer ${token}" \
+              "${node_url}${path}")
+            code=$body
+            echo "GET ${node_url}${path} → HTTP ${code}" >&2
+            head -c 400 /tmp/probe.body >&2; echo >&2
+            cat /tmp/probe.body
+          }
+
+          echo "--- discover application ---"
+          APPS=$(probe_admin "${NODE_1_URL}" "/admin-api/applications" "${ACCESS_TOKEN_1}")
           APP_ID=$(echo "$APPS" | jq -r '
             (.data // .) |
             if type == "array" then .[0].applicationId // .[0].id
             elif type == "object" then (.applications[0].applicationId // .items[0].applicationId)
             else empty end' 2>/dev/null || echo "")
 
-          GROUPS=$(curl -sf "${NODE_1_URL}/admin-api/groups" \
-            -H "Authorization: Bearer ${ACCESS_TOKEN_1}")
+          echo "--- discover groups ---"
+          GROUPS=$(probe_admin "${NODE_1_URL}" "/admin-api/groups" "${ACCESS_TOKEN_1}")
           NS_ID=$(echo "$GROUPS" | jq -r '
             (.data // .) |
             if type == "array" then .[0].groupId
             elif type == "object" then (.groups[0].groupId // .items[0].groupId)
             else empty end' 2>/dev/null || echo "")
 
-          CTXS=$(curl -sf "${NODE_1_URL}/admin-api/contexts" \
-            -H "Authorization: Bearer ${ACCESS_TOKEN_1}")
+          echo "--- discover contexts ---"
+          CTXS=$(probe_admin "${NODE_1_URL}" "/admin-api/contexts" "${ACCESS_TOKEN_1}")
           CTX_ID=$(echo "$CTXS" | jq -r '
             (.data // .) |
             if type == "array" then .[0].id // .[0].contextId
@@ -240,18 +255,15 @@ jobs:
           MEMBER_KEY_1=""
           MEMBER_KEY_2=""
           if [ -n "$CTX_ID" ]; then
-            IDS_1=$(curl -sf \
-              "${NODE_1_URL}/admin-api/contexts/${CTX_ID}/identities-owned" \
-              -H "Authorization: Bearer ${ACCESS_TOKEN_1}")
+            echo "--- discover member keys ---"
+            IDS_1=$(probe_admin "${NODE_1_URL}" "/admin-api/contexts/${CTX_ID}/identities-owned" "${ACCESS_TOKEN_1}")
             MEMBER_KEY_1=$(echo "$IDS_1" | jq -r '
               (.data // .) |
               if type == "array" then .[0]
               elif type == "object" then (.identities[0] // .items[0])
               else empty end' 2>/dev/null || echo "")
 
-            IDS_2=$(curl -sf \
-              "${NODE_2_URL}/admin-api/contexts/${CTX_ID}/identities-owned" \
-              -H "Authorization: Bearer ${ACCESS_TOKEN_2}")
+            IDS_2=$(probe_admin "${NODE_2_URL}" "/admin-api/contexts/${CTX_ID}/identities-owned" "${ACCESS_TOKEN_2}")
             MEMBER_KEY_2=$(echo "$IDS_2" | jq -r '
               (.data // .) |
               if type == "array" then .[0]

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -161,24 +161,21 @@ jobs:
           ADMIN_USER="${E2E_ADMIN_USER:-admin}"
           ADMIN_PASS="${E2E_ADMIN_PASS:-calimero1234}"
 
-          echo "--- DNS / endpoint smoke ---"
-          getent hosts node1.127.0.0.1.nip.io || echo "(getent: not found)"
-          curl -sS -o /tmp/probe.out -w "GET ${NODE_1_URL}/ → HTTP %{http_code}\n" "${NODE_1_URL}/" || true
-          curl -sS -o /tmp/probe.out -w "GET ${NODE_1_URL}/admin-api/health → HTTP %{http_code}\n" "${NODE_1_URL}/admin-api/health" || true
-          curl -sS -o /tmp/probe.out -w "GET http://localhost:80/ → HTTP %{http_code}\n" "http://localhost:80/" || true
-          curl -sS -o /tmp/probe.out -w "GET localhost:80 (Host: node1.…nip.io) → HTTP %{http_code}\n" -H "Host: node1.127.0.0.1.nip.io" "http://localhost:80/admin-api/health" || true
-          echo "--- /etc/hosts excerpt ---"
-          grep -E "(127\.0\.0\.1|node[12])" /etc/hosts || true
-
-          echo "Waiting for both nodes to be healthy..."
+          # /admin-api/health requires a valid JWT, so we can't use it as a
+          # readiness probe. /auth/login is served by the auth-service and
+          # responds 200 unauthenticated as soon as the proxy + auth stack
+          # are up; both nodes share the proxy, so probing one URL per node
+          # confirms Traefik is routing host-headers correctly.
+          echo "Waiting for auth-service to accept requests on both nodes..."
           for i in $(seq 1 30); do
-            if curl -sf "${NODE_1_URL}/admin-api/health" >/dev/null 2>&1 && \
-               curl -sf "${NODE_2_URL}/admin-api/health" >/dev/null 2>&1; then
-              echo "Both nodes healthy (attempt ${i})"
+            CODE_1=$(curl -s -o /dev/null -w "%{http_code}" "${NODE_1_URL}/auth/login" || echo "000")
+            CODE_2=$(curl -s -o /dev/null -w "%{http_code}" "${NODE_2_URL}/auth/login" || echo "000")
+            if [ "${CODE_1:0:1}" = "2" ] && [ "${CODE_2:0:1}" = "2" ]; then
+              echo "Both nodes routable (attempt ${i})  node1=${CODE_1} node2=${CODE_2}"
               break
             fi
             if [ "$i" -eq 30 ]; then
-              echo "Nodes not healthy after 60s"
+              echo "Nodes not routable after 60s  node1=${CODE_1} node2=${CODE_2}"
               exit 1
             fi
             sleep 2

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -181,9 +181,12 @@ jobs:
             sleep 2
           done
 
+          # No -f: 4xx/5xx must not abort the script under `set -e`. We
+          # validate the JSON shape after each call so a meaningful error
+          # bubbles up instead of a silent exit.
           mint_token() {
             local node_url=$1
-            curl -sf -X POST "${node_url}/auth/token" \
+            curl -sS -X POST "${node_url}/auth/token" \
               -H "Content-Type: application/json" \
               -d "{
                 \"auth_method\":  \"user_password\",
@@ -195,8 +198,12 @@ jobs:
               }"
           }
 
+          echo "--- mint token (node 1) ---"
           AUTH_1=$(mint_token "${NODE_1_URL}")
+          echo "$AUTH_1" | head -c 500; echo
+          echo "--- mint token (node 2) ---"
           AUTH_2=$(mint_token "${NODE_2_URL}")
+          echo "$AUTH_2" | head -c 500; echo
 
           ACCESS_TOKEN_1=$(echo "$AUTH_1" | jq -r '.data.access_token // empty')
           REFRESH_TOKEN_1=$(echo "$AUTH_1" | jq -r '.data.refresh_token // empty')

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -106,7 +106,13 @@ jobs:
 
           merobox stop --all 2>/dev/null || true
           merobox nuke --force 2>/dev/null || true
-          merobox bootstrap run workflow-battleships-integration-setup.yml --e2e-mode
+          # No --e2e-mode here: that flag forces post-workflow node teardown,
+          # which would defeat stop_all_nodes:false. The Playwright job needs
+          # the merod containers to outlive the merobox process.
+          merobox bootstrap run workflow-battleships-integration-setup.yml
+
+          echo "--- docker ps after setup ---"
+          docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' || true
 
       # Mint JWTs and discover IDs
       - name: Bootstrap auth and write env file

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -230,45 +230,25 @@ jobs:
 
           echo "--- discover application ---"
           APPS=$(probe_admin "${NODE_1_URL}" "/admin-api/applications" "${ACCESS_TOKEN_1}")
-          APP_ID=$(echo "$APPS" | jq -r '
-            (.data // .) |
-            if type == "array" then .[0].applicationId // .[0].id
-            elif type == "object" then (.applications[0].applicationId // .items[0].applicationId)
-            else empty end' 2>/dev/null || echo "")
+          APP_ID=$(echo "$APPS" | jq -r '.data.apps[0].id // empty')
 
-          echo "--- discover groups ---"
-          GROUPS=$(probe_admin "${NODE_1_URL}" "/admin-api/groups" "${ACCESS_TOKEN_1}")
-          NS_ID=$(echo "$GROUPS" | jq -r '
-            (.data // .) |
-            if type == "array" then .[0].groupId
-            elif type == "object" then (.groups[0].groupId // .items[0].groupId)
-            else empty end' 2>/dev/null || echo "")
+          echo "--- discover namespace ---"
+          NS_RESP=$(probe_admin "${NODE_1_URL}" "/admin-api/namespaces" "${ACCESS_TOKEN_1}")
+          NS_ID=$(echo "$NS_RESP" | jq -r '.data[0].namespaceId // empty')
 
-          echo "--- discover contexts ---"
+          echo "--- discover lobby context ---"
           CTXS=$(probe_admin "${NODE_1_URL}" "/admin-api/contexts" "${ACCESS_TOKEN_1}")
-          CTX_ID=$(echo "$CTXS" | jq -r '
-            (.data // .) |
-            if type == "array" then .[0].id // .[0].contextId
-            elif type == "object" then (.contexts[0].id // .contexts[0].contextId)
-            else empty end' 2>/dev/null || echo "")
+          CTX_ID=$(echo "$CTXS" | jq -r '.data.contexts[0].id // empty')
 
           MEMBER_KEY_1=""
           MEMBER_KEY_2=""
           if [ -n "$CTX_ID" ]; then
             echo "--- discover member keys ---"
             IDS_1=$(probe_admin "${NODE_1_URL}" "/admin-api/contexts/${CTX_ID}/identities-owned" "${ACCESS_TOKEN_1}")
-            MEMBER_KEY_1=$(echo "$IDS_1" | jq -r '
-              (.data // .) |
-              if type == "array" then .[0]
-              elif type == "object" then (.identities[0] // .items[0])
-              else empty end' 2>/dev/null || echo "")
+            MEMBER_KEY_1=$(echo "$IDS_1" | jq -r '.data.identities[0] // empty')
 
             IDS_2=$(probe_admin "${NODE_2_URL}" "/admin-api/contexts/${CTX_ID}/identities-owned" "${ACCESS_TOKEN_2}")
-            MEMBER_KEY_2=$(echo "$IDS_2" | jq -r '
-              (.data // .) |
-              if type == "array" then .[0]
-              elif type == "object" then (.identities[0] // .items[0])
-              else empty end' 2>/dev/null || echo "")
+            MEMBER_KEY_2=$(echo "$IDS_2" | jq -r '.data.identities[0] // empty')
           fi
 
           [ -n "$APP_ID" ]       || { echo "Failed to discover application id"; exit 1; }

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -214,21 +214,21 @@ jobs:
           echo "MEMBER_1:  $MEMBER_KEY_1"
           echo "MEMBER_2:  $MEMBER_KEY_2"
 
-          cat > app/.env.integration << ENVEOF
-E2E_APPLICATION_ID=${APP_ID}
-E2E_NAMESPACE_ID=${NS_ID}
-E2E_LOBBY_CONTEXT_ID=${CTX_ID}
-
-E2E_NODE_URL=${NODE_1_URL}
-E2E_ACCESS_TOKEN=${ACCESS_TOKEN_1}
-E2E_REFRESH_TOKEN=${REFRESH_TOKEN_1}
-E2E_MEMBER_KEY=${MEMBER_KEY_1}
-
-E2E_NODE_URL_2=${NODE_2_URL}
-E2E_ACCESS_TOKEN_2=${ACCESS_TOKEN_2}
-E2E_REFRESH_TOKEN_2=${REFRESH_TOKEN_2}
-E2E_MEMBER_KEY_2=${MEMBER_KEY_2}
-ENVEOF
+          printf '%s\n' \
+            "E2E_APPLICATION_ID=${APP_ID}" \
+            "E2E_NAMESPACE_ID=${NS_ID}" \
+            "E2E_LOBBY_CONTEXT_ID=${CTX_ID}" \
+            "" \
+            "E2E_NODE_URL=${NODE_1_URL}" \
+            "E2E_ACCESS_TOKEN=${ACCESS_TOKEN_1}" \
+            "E2E_REFRESH_TOKEN=${REFRESH_TOKEN_1}" \
+            "E2E_MEMBER_KEY=${MEMBER_KEY_1}" \
+            "" \
+            "E2E_NODE_URL_2=${NODE_2_URL}" \
+            "E2E_ACCESS_TOKEN_2=${ACCESS_TOKEN_2}" \
+            "E2E_REFRESH_TOKEN_2=${REFRESH_TOKEN_2}" \
+            "E2E_MEMBER_KEY_2=${MEMBER_KEY_2}" \
+            > app/.env.integration
           echo "app/.env.integration written"
 
       # Frontend setup

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -1,0 +1,308 @@
+# Full-stack browser integration tests.
+#
+# Builds the WASM bundle against current core master, brings up two merod
+# nodes via merobox, seeds a namespace + lobby + two members, mints JWTs,
+# then runs the Playwright suite against the live stack from a real browser.
+#
+# Phase A (merobox setup) runs the lean `workflow-battleships-integration-setup.yml`
+# which stops short of match creation. Match + gameplay are driven by Playwright.
+
+name: Integration Tests (Browser)
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "app/**"
+      - "logic/**"
+      - "e2e/workflow-battleships-integration-setup.yml"
+      - "e2e/workflow-battleships-e2e.yml"
+      - ".github/workflows/integration-ci.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - "app/**"
+      - "logic/**"
+      - "e2e/workflow-battleships-integration-setup.yml"
+      - "e2e/workflow-battleships-e2e.yml"
+      - ".github/workflows/integration-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    name: Browser Integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      SHA: ${{ github.sha }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Build WASM bundle
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            logic/target
+          key: integration-${{ runner.os }}-${{ hashFiles('logic/Cargo.toml', 'logic/crates/*/Cargo.toml') }}
+          restore-keys: integration-${{ runner.os }}-
+
+      - name: Build bundle
+        working-directory: logic
+        run: ./build-bundle.sh
+
+      # Install merobox (signed apt release)
+      - name: Install merobox
+        run: |
+          curl -fsSL https://calimero-network.github.io/merobox/gpg.key \
+            | sudo tee /usr/share/keyrings/merobox.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/merobox.gpg] https://calimero-network.github.io/merobox stable main" \
+            | sudo tee /etc/apt/sources.list.d/merobox.list
+          sudo apt-get update
+          sudo apt-get install -y merobox
+          merobox --version
+
+      # Run setup workflow (stop_all_nodes: false leaves nodes alive)
+      - name: Run Battleships Integration Setup
+        working-directory: e2e
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/docker-logs"
+          LOGDIR="$GITHUB_WORKSPACE/docker-logs"
+          WATCHER_STATE_DIR="$(mktemp -d)"
+          ATTEMPT_FILE="$WATCHER_STATE_DIR/.attempt"
+          echo 1 > "$ATTEMPT_FILE"
+          (
+              while [ ! -f "$WATCHER_STATE_DIR/stop" ]; do
+                  cur=$(cat "$ATTEMPT_FILE" 2>/dev/null || echo 1)
+                  for c in $(docker ps --filter "label=calimero.node=true" --format "{{.Names}}" 2>/dev/null | grep -v -- '-init$' || true); do
+                      mark="$WATCHER_STATE_DIR/${c}-attempt${cur}"
+                      if [ ! -f "$mark" ]; then
+                          touch "$mark"
+                          echo "[log-watcher] following $c (attempt $cur)"
+                          docker logs -f "$c" > "$LOGDIR/setup-${c}.log" 2>&1 &
+                      fi
+                  done
+                  sleep 1
+              done
+          ) &
+          WATCHER_PID=$!
+          echo "WATCHER_PID=$WATCHER_PID" >> "$GITHUB_ENV"
+          echo "WATCHER_STATE_DIR=$WATCHER_STATE_DIR" >> "$GITHUB_ENV"
+
+          merobox stop --all 2>/dev/null || true
+          merobox nuke --force 2>/dev/null || true
+          merobox bootstrap run workflow-battleships-integration-setup.yml --e2e-mode
+
+      # Mint JWTs and discover IDs
+      - name: Bootstrap auth and write env file
+        run: |
+          set -euo pipefail
+          NODE_1_URL="http://localhost:2428"
+          NODE_2_URL="http://localhost:2429"
+          ADMIN_USER="${E2E_ADMIN_USER:-admin}"
+          ADMIN_PASS="${E2E_ADMIN_PASS:-calimero1234}"
+
+          echo "Waiting for both nodes to be healthy..."
+          for i in $(seq 1 30); do
+            if curl -sf "${NODE_1_URL}/admin-api/health" >/dev/null 2>&1 && \
+               curl -sf "${NODE_2_URL}/admin-api/health" >/dev/null 2>&1; then
+              echo "Both nodes healthy (attempt ${i})"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Nodes not healthy after 60s"
+              exit 1
+            fi
+            sleep 2
+          done
+
+          mint_token() {
+            local node_url=$1
+            curl -sf -X POST "${node_url}/auth/token" \
+              -H "Content-Type: application/json" \
+              -d "{
+                \"auth_method\":  \"user_password\",
+                \"public_key\":   \"${ADMIN_USER}\",
+                \"client_name\":  \"battleships-integration-ci\",
+                \"timestamp\":    0,
+                \"permissions\":  [],
+                \"provider_data\": {\"username\": \"${ADMIN_USER}\", \"password\": \"${ADMIN_PASS}\"}
+              }"
+          }
+
+          AUTH_1=$(mint_token "${NODE_1_URL}")
+          AUTH_2=$(mint_token "${NODE_2_URL}")
+
+          ACCESS_TOKEN_1=$(echo "$AUTH_1" | jq -r '.data.access_token // empty')
+          REFRESH_TOKEN_1=$(echo "$AUTH_1" | jq -r '.data.refresh_token // empty')
+          ACCESS_TOKEN_2=$(echo "$AUTH_2" | jq -r '.data.access_token // empty')
+          REFRESH_TOKEN_2=$(echo "$AUTH_2" | jq -r '.data.refresh_token // empty')
+
+          [ -n "$ACCESS_TOKEN_1" ] || { echo "Node 1 auth failed: $AUTH_1"; exit 1; }
+          [ -n "$ACCESS_TOKEN_2" ] || { echo "Node 2 auth failed: $AUTH_2"; exit 1; }
+
+          APPS=$(curl -sf "${NODE_1_URL}/admin-api/applications" \
+            -H "Authorization: Bearer ${ACCESS_TOKEN_1}")
+          APP_ID=$(echo "$APPS" | jq -r '
+            (.data // .) |
+            if type == "array" then .[0].applicationId // .[0].id
+            elif type == "object" then (.applications[0].applicationId // .items[0].applicationId)
+            else empty end' 2>/dev/null || echo "")
+
+          GROUPS=$(curl -sf "${NODE_1_URL}/admin-api/groups" \
+            -H "Authorization: Bearer ${ACCESS_TOKEN_1}")
+          NS_ID=$(echo "$GROUPS" | jq -r '
+            (.data // .) |
+            if type == "array" then .[0].groupId
+            elif type == "object" then (.groups[0].groupId // .items[0].groupId)
+            else empty end' 2>/dev/null || echo "")
+
+          CTXS=$(curl -sf "${NODE_1_URL}/admin-api/contexts" \
+            -H "Authorization: Bearer ${ACCESS_TOKEN_1}")
+          CTX_ID=$(echo "$CTXS" | jq -r '
+            (.data // .) |
+            if type == "array" then .[0].id // .[0].contextId
+            elif type == "object" then (.contexts[0].id // .contexts[0].contextId)
+            else empty end' 2>/dev/null || echo "")
+
+          MEMBER_KEY_1=""
+          MEMBER_KEY_2=""
+          if [ -n "$CTX_ID" ]; then
+            IDS_1=$(curl -sf \
+              "${NODE_1_URL}/admin-api/contexts/${CTX_ID}/identities-owned" \
+              -H "Authorization: Bearer ${ACCESS_TOKEN_1}")
+            MEMBER_KEY_1=$(echo "$IDS_1" | jq -r '
+              (.data // .) |
+              if type == "array" then .[0]
+              elif type == "object" then (.identities[0] // .items[0])
+              else empty end' 2>/dev/null || echo "")
+
+            IDS_2=$(curl -sf \
+              "${NODE_2_URL}/admin-api/contexts/${CTX_ID}/identities-owned" \
+              -H "Authorization: Bearer ${ACCESS_TOKEN_2}")
+            MEMBER_KEY_2=$(echo "$IDS_2" | jq -r '
+              (.data // .) |
+              if type == "array" then .[0]
+              elif type == "object" then (.identities[0] // .items[0])
+              else empty end' 2>/dev/null || echo "")
+          fi
+
+          [ -n "$APP_ID" ]       || { echo "Failed to discover application id"; exit 1; }
+          [ -n "$NS_ID" ]        || { echo "Failed to discover namespace id";   exit 1; }
+          [ -n "$CTX_ID" ]       || { echo "Failed to discover lobby context";  exit 1; }
+          [ -n "$MEMBER_KEY_1" ] || { echo "Failed to discover node-1 member key"; exit 1; }
+          [ -n "$MEMBER_KEY_2" ] || { echo "Failed to discover node-2 member key"; exit 1; }
+
+          echo "APP_ID:    $APP_ID"
+          echo "NS_ID:     $NS_ID"
+          echo "CTX_ID:    $CTX_ID"
+          echo "MEMBER_1:  $MEMBER_KEY_1"
+          echo "MEMBER_2:  $MEMBER_KEY_2"
+
+          cat > app/.env.integration << ENVEOF
+E2E_APPLICATION_ID=${APP_ID}
+E2E_NAMESPACE_ID=${NS_ID}
+E2E_LOBBY_CONTEXT_ID=${CTX_ID}
+
+E2E_NODE_URL=${NODE_1_URL}
+E2E_ACCESS_TOKEN=${ACCESS_TOKEN_1}
+E2E_REFRESH_TOKEN=${REFRESH_TOKEN_1}
+E2E_MEMBER_KEY=${MEMBER_KEY_1}
+
+E2E_NODE_URL_2=${NODE_2_URL}
+E2E_ACCESS_TOKEN_2=${ACCESS_TOKEN_2}
+E2E_REFRESH_TOKEN_2=${REFRESH_TOKEN_2}
+E2E_MEMBER_KEY_2=${MEMBER_KEY_2}
+ENVEOF
+          echo "app/.env.integration written"
+
+      # Frontend setup
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: app/pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        working-directory: app
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('app/pnpm-lock.yaml') }}
+          restore-keys: playwright-${{ runner.os }}-
+
+      - name: Install Playwright Chromium
+        working-directory: app
+        run: pnpm exec playwright install chromium --with-deps
+
+      # Run Playwright integration project
+      - name: Run integration tests
+        working-directory: app
+        env:
+          CI: "true"
+          INTEGRATION_MODE: "true"
+        run: pnpm exec playwright test --project=integration
+
+      # Cleanup
+      - name: Stop merod nodes
+        if: always()
+        run: |
+          if [ -n "${WATCHER_STATE_DIR:-}" ]; then
+            touch "$WATCHER_STATE_DIR/stop" || true
+          fi
+          if [ -n "${WATCHER_PID:-}" ]; then
+            kill "$WATCHER_PID" 2>/dev/null || true
+          fi
+          for pid in $(jobs -p); do kill "$pid" 2>/dev/null || true; done
+          merobox stop --all 2>/dev/null || true
+          merobox nuke --force 2>/dev/null || true
+
+      # Artifacts
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ env.SHA }}
+          path: app/playwright-report/
+          retention-days: 7
+
+      - name: Upload Playwright traces & test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces-${{ env.SHA }}
+          path: app/test-results/
+          retention-days: 7
+
+      - name: Upload merod docker logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-docker-logs-${{ env.SHA }}
+          path: docker-logs/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -68,13 +68,10 @@ jobs:
 
       - name: Install merobox
         run: |
-          curl -fsSL https://calimero-network.github.io/merobox/gpg.key \
-            | sudo tee /usr/share/keyrings/merobox.gpg > /dev/null
-          echo "deb [signed-by=/usr/share/keyrings/merobox.gpg] https://calimero-network.github.io/merobox stable main" \
-            | sudo tee /etc/apt/sources.list.d/merobox.list
-          sudo apt-get update
-          sudo apt-get install -y merobox
-          merobox --version
+          python3 -m pip install --user --upgrade pip
+          python3 -m pip install --user "merobox==0.6.9"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/merobox" --version
 
       # Run setup workflow (stop_all_nodes: false leaves nodes alive)
       - name: Run Battleships Integration Setup

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -66,16 +66,15 @@ jobs:
         working-directory: logic
         run: ./build-bundle.sh
 
-      # Install merobox (signed apt release)
+      # Install merobox from the PR branch with the forward-auth CORS fix
+      # (calimero-network/merobox#229). Pinned until 0.6.9 ships to apt stable.
       - name: Install merobox
         run: |
-          curl -fsSL https://calimero-network.github.io/merobox/gpg.key \
-            | sudo tee /usr/share/keyrings/merobox.gpg > /dev/null
-          echo "deb [signed-by=/usr/share/keyrings/merobox.gpg] https://calimero-network.github.io/merobox stable main" \
-            | sudo tee /etc/apt/sources.list.d/merobox.list
-          sudo apt-get update
-          sudo apt-get install -y merobox
-          merobox --version
+          python3 -m pip install --user --upgrade pip
+          python3 -m pip install --user \
+            "git+https://github.com/calimero-network/merobox.git@fix/traefik-cors-preflight-228"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/merobox" --version
 
       # Run setup workflow (stop_all_nodes: false leaves nodes alive)
       - name: Run Battleships Integration Setup
@@ -152,36 +151,62 @@ jobs:
             exit 1
           fi
 
-      # Mint JWTs and discover IDs
+      # Mint JWTs and discover IDs (auth_service: true → Bearer required)
       - name: Bootstrap auth and write env file
         run: |
           set -euo pipefail
-          NODE_1_URL="http://localhost:2528"
-          NODE_2_URL="http://localhost:2529"
+          NODE_1_URL="http://node1.127.0.0.1.nip.io"
+          NODE_2_URL="http://node2.127.0.0.1.nip.io"
+          ADMIN_USER="${E2E_ADMIN_USER:-admin}"
+          ADMIN_PASS="${E2E_ADMIN_PASS:-calimero1234}"
 
-          # Without auth_service, merod admin API is unauthenticated and
-          # CORS-wildcard. Probe /admin-api/contexts directly: any 2xx
-          # confirms the node is up and the API is responding.
-          echo "Waiting for both merod admin APIs to come up..."
-          for i in $(seq 1 30); do
-            CODE_1=$(curl -s -o /dev/null -w "%{http_code}" "${NODE_1_URL}/admin-api/contexts" || echo "000")
-            CODE_2=$(curl -s -o /dev/null -w "%{http_code}" "${NODE_2_URL}/admin-api/contexts" || echo "000")
+          echo "Waiting for the auth proxy + both nodes to come up..."
+          for i in $(seq 1 60); do
+            CODE_1=$(curl -s -o /dev/null -w "%{http_code}" "${NODE_1_URL}/auth/login" || echo "000")
+            CODE_2=$(curl -s -o /dev/null -w "%{http_code}" "${NODE_2_URL}/auth/login" || echo "000")
             if [ "${CODE_1:0:1}" = "2" ] && [ "${CODE_2:0:1}" = "2" ]; then
-              echo "Both nodes responding (attempt ${i})  node1=${CODE_1} node2=${CODE_2}"
+              echo "Auth proxy ready (attempt ${i})  node1=${CODE_1} node2=${CODE_2}"
               break
             fi
-            if [ "$i" -eq 30 ]; then
-              echo "Nodes not responding after 60s  node1=${CODE_1} node2=${CODE_2}"
+            if [ "$i" -eq 60 ]; then
+              echo "Auth proxy not ready after 120s  node1=${CODE_1} node2=${CODE_2}"
               exit 1
             fi
             sleep 2
           done
 
+          mint_token() {
+            local node_url=$1
+            curl -sS -X POST "${node_url}/auth/token" \
+              -H "Content-Type: application/json" \
+              -d "{
+                \"auth_method\":   \"user_password\",
+                \"public_key\":    \"${ADMIN_USER}\",
+                \"client_name\":   \"battleships-integration-ci\",
+                \"timestamp\":     0,
+                \"permissions\":   [],
+                \"provider_data\": {\"username\": \"${ADMIN_USER}\", \"password\": \"${ADMIN_PASS}\"}
+              }"
+          }
+
+          AUTH_1=$(mint_token "${NODE_1_URL}")
+          AUTH_2=$(mint_token "${NODE_2_URL}")
+
+          ACCESS_TOKEN_1=$(echo "$AUTH_1" | jq -r '.data.access_token // empty')
+          REFRESH_TOKEN_1=$(echo "$AUTH_1" | jq -r '.data.refresh_token // empty')
+          ACCESS_TOKEN_2=$(echo "$AUTH_2" | jq -r '.data.access_token // empty')
+          REFRESH_TOKEN_2=$(echo "$AUTH_2" | jq -r '.data.refresh_token // empty')
+
+          [ -n "$ACCESS_TOKEN_1" ] || { echo "Node 1 auth failed: $AUTH_1"; exit 1; }
+          [ -n "$ACCESS_TOKEN_2" ] || { echo "Node 2 auth failed: $AUTH_2"; exit 1; }
+
           probe_admin() {
             local node_url=$1
             local path=$2
+            local token=$3
             local body
             body=$(curl -sS -o /tmp/probe.body -w "%{http_code}" \
+              -H "Authorization: Bearer ${token}" \
               "${node_url}${path}")
             echo "GET ${node_url}${path} → HTTP ${body}" >&2
             head -c 400 /tmp/probe.body >&2; echo >&2
@@ -189,34 +214,27 @@ jobs:
           }
 
           echo "--- discover application ---"
-          APPS=$(probe_admin "${NODE_1_URL}" "/admin-api/applications")
+          APPS=$(probe_admin "${NODE_1_URL}" "/admin-api/applications" "${ACCESS_TOKEN_1}")
           APP_ID=$(echo "$APPS" | jq -r '.data.apps[0].id // empty')
 
           echo "--- discover namespace ---"
-          NS_RESP=$(probe_admin "${NODE_1_URL}" "/admin-api/namespaces")
+          NS_RESP=$(probe_admin "${NODE_1_URL}" "/admin-api/namespaces" "${ACCESS_TOKEN_1}")
           NS_ID=$(echo "$NS_RESP" | jq -r '.data[0].namespaceId // empty')
 
           echo "--- discover lobby context ---"
-          CTXS=$(probe_admin "${NODE_1_URL}" "/admin-api/contexts")
+          CTXS=$(probe_admin "${NODE_1_URL}" "/admin-api/contexts" "${ACCESS_TOKEN_1}")
           CTX_ID=$(echo "$CTXS" | jq -r '.data.contexts[0].id // empty')
 
           MEMBER_KEY_1=""
           MEMBER_KEY_2=""
           if [ -n "$CTX_ID" ]; then
             echo "--- discover member keys ---"
-            IDS_1=$(probe_admin "${NODE_1_URL}" "/admin-api/contexts/${CTX_ID}/identities-owned")
+            IDS_1=$(probe_admin "${NODE_1_URL}" "/admin-api/contexts/${CTX_ID}/identities-owned" "${ACCESS_TOKEN_1}")
             MEMBER_KEY_1=$(echo "$IDS_1" | jq -r '.data.identities[0] // empty')
 
-            IDS_2=$(probe_admin "${NODE_2_URL}" "/admin-api/contexts/${CTX_ID}/identities-owned")
+            IDS_2=$(probe_admin "${NODE_2_URL}" "/admin-api/contexts/${CTX_ID}/identities-owned" "${ACCESS_TOKEN_2}")
             MEMBER_KEY_2=$(echo "$IDS_2" | jq -r '.data.identities[0] // empty')
           fi
-
-          # Tokens are not required when auth_service is off — keep the
-          # vars empty; tests just won't write a Bearer header.
-          ACCESS_TOKEN_1=""
-          REFRESH_TOKEN_1=""
-          ACCESS_TOKEN_2=""
-          REFRESH_TOKEN_2=""
 
           [ -n "$APP_ID" ]       || { echo "Failed to discover application id"; exit 1; }
           [ -n "$NS_ID" ]        || { echo "Failed to discover namespace id";   exit 1; }

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -161,6 +161,15 @@ jobs:
           ADMIN_USER="${E2E_ADMIN_USER:-admin}"
           ADMIN_PASS="${E2E_ADMIN_PASS:-calimero1234}"
 
+          echo "--- DNS / endpoint smoke ---"
+          getent hosts node1.127.0.0.1.nip.io || echo "(getent: not found)"
+          curl -sS -o /tmp/probe.out -w "GET ${NODE_1_URL}/ → HTTP %{http_code}\n" "${NODE_1_URL}/" || true
+          curl -sS -o /tmp/probe.out -w "GET ${NODE_1_URL}/admin-api/health → HTTP %{http_code}\n" "${NODE_1_URL}/admin-api/health" || true
+          curl -sS -o /tmp/probe.out -w "GET http://localhost:80/ → HTTP %{http_code}\n" "http://localhost:80/" || true
+          curl -sS -o /tmp/probe.out -w "GET localhost:80 (Host: node1.…nip.io) → HTTP %{http_code}\n" -H "Host: node1.127.0.0.1.nip.io" "http://localhost:80/admin-api/health" || true
+          echo "--- /etc/hosts excerpt ---"
+          grep -E "(127\.0\.0\.1|node[12])" /etc/hosts || true
+
           echo "Waiting for both nodes to be healthy..."
           for i in $(seq 1 30); do
             if curl -sf "${NODE_1_URL}/admin-api/health" >/dev/null 2>&1 && \

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -112,8 +112,8 @@ jobs:
       - name: Bootstrap auth and write env file
         run: |
           set -euo pipefail
-          NODE_1_URL="http://localhost:2428"
-          NODE_2_URL="http://localhost:2429"
+          NODE_1_URL="http://localhost:2528"
+          NODE_2_URL="http://localhost:2529"
           ADMIN_USER="${E2E_ADMIN_USER:-admin}"
           ADMIN_PASS="${E2E_ADMIN_PASS:-calimero1234}"
 

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -112,8 +112,8 @@ jobs:
       - name: Bootstrap auth and write env file
         run: |
           set -euo pipefail
-          NODE_1_URL="http://localhost:2528"
-          NODE_2_URL="http://localhost:2529"
+          NODE_1_URL="http://node1.127.0.0.1.nip.io"
+          NODE_2_URL="http://node2.127.0.0.1.nip.io"
           ADMIN_USER="${E2E_ADMIN_USER:-admin}"
           ADMIN_PASS="${E2E_ADMIN_PASS:-calimero1234}"
 

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -106,13 +106,51 @@ jobs:
 
           merobox stop --all 2>/dev/null || true
           merobox nuke --force 2>/dev/null || true
-          # No --e2e-mode here: that flag forces post-workflow node teardown,
-          # which would defeat stop_all_nodes:false. The Playwright job needs
-          # the merod containers to outlive the merobox process.
-          merobox bootstrap run workflow-battleships-integration-setup.yml
+
+          # merobox's CleanupMixin registers an atexit handler that
+          # unconditionally tears down its tracked containers when the
+          # python process exits, which makes `stop_all_nodes: false`
+          # ineffective at keeping nodes alive after the CLI returns.
+          # We run it in the background and SIGKILL once the workflow
+          # logs "Workflow completed successfully!" — SIGKILL bypasses
+          # atexit and the docker containers (separate process tree)
+          # outlive merobox.
+          MEROBOX_LOG="$GITHUB_WORKSPACE/docker-logs/merobox-setup.log"
+          merobox bootstrap run workflow-battleships-integration-setup.yml \
+            > "$MEROBOX_LOG" 2>&1 &
+          MEROBOX_PID=$!
+          echo "merobox PID=$MEROBOX_PID, log=$MEROBOX_LOG"
+
+          # Wait up to 5 minutes for the workflow to finish. We watch for
+          # the success line; on failure merobox will exit on its own and
+          # the wait $MEROBOX_PID below will return non-zero.
+          for i in $(seq 1 300); do
+            if grep -q "Workflow completed successfully" "$MEROBOX_LOG" 2>/dev/null; then
+              echo "merobox setup workflow completed; SIGKILLing to skip atexit cleanup"
+              kill -9 "$MEROBOX_PID" 2>/dev/null || true
+              break
+            fi
+            if ! kill -0 "$MEROBOX_PID" 2>/dev/null; then
+              echo "merobox process exited before completion line — workflow failed"
+              tail -100 "$MEROBOX_LOG" || true
+              exit 1
+            fi
+            sleep 1
+          done
+          wait "$MEROBOX_PID" 2>/dev/null || true
 
           echo "--- docker ps after setup ---"
           docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' || true
+
+          # Sanity check: both merod containers must still be running.
+          if ! docker ps --format '{{.Names}}' | grep -q '^calimero-node-1$'; then
+            echo "calimero-node-1 not running after setup — cannot continue"
+            exit 1
+          fi
+          if ! docker ps --format '{{.Names}}' | grep -q '^calimero-node-2$'; then
+            echo "calimero-node-2 not running after setup — cannot continue"
+            exit 1
+          fi
 
       # Mint JWTs and discover IDs
       - name: Bootstrap auth and write env file

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -66,9 +66,6 @@ jobs:
         working-directory: logic
         run: ./build-bundle.sh
 
-      # Install merobox from master. The forward-auth CORS preflight fix
-      # (calimero-network/merobox#229) is on master but not yet in the apt
-      # stable channel; switch back to apt once a 0.6.9+ release ships.
       - name: Install merobox
         run: |
           python3 -m pip install --user --upgrade pip

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -66,13 +66,14 @@ jobs:
         working-directory: logic
         run: ./build-bundle.sh
 
-      # Install merobox from the PR branch with the forward-auth CORS fix
-      # (calimero-network/merobox#229). Pinned until 0.6.9 ships to apt stable.
+      # Install merobox from master. The forward-auth CORS preflight fix
+      # (calimero-network/merobox#229) is on master but not yet in the apt
+      # stable channel; switch back to apt once a 0.6.9+ release ships.
       - name: Install merobox
         run: |
           python3 -m pip install --user --upgrade pip
           python3 -m pip install --user \
-            "git+https://github.com/calimero-network/merobox.git@fix/traefik-cors-preflight-228"
+            "git+https://github.com/calimero-network/merobox.git@master"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/merobox" --version
 

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -156,100 +156,67 @@ jobs:
       - name: Bootstrap auth and write env file
         run: |
           set -euo pipefail
-          NODE_1_URL="http://node1.127.0.0.1.nip.io"
-          NODE_2_URL="http://node2.127.0.0.1.nip.io"
-          ADMIN_USER="${E2E_ADMIN_USER:-admin}"
-          ADMIN_PASS="${E2E_ADMIN_PASS:-calimero1234}"
+          NODE_1_URL="http://localhost:2528"
+          NODE_2_URL="http://localhost:2529"
 
-          # /admin-api/health requires a valid JWT, so we can't use it as a
-          # readiness probe. /auth/login is served by the auth-service and
-          # responds 200 unauthenticated as soon as the proxy + auth stack
-          # are up; both nodes share the proxy, so probing one URL per node
-          # confirms Traefik is routing host-headers correctly.
-          echo "Waiting for auth-service to accept requests on both nodes..."
+          # Without auth_service, merod admin API is unauthenticated and
+          # CORS-wildcard. Probe /admin-api/contexts directly: any 2xx
+          # confirms the node is up and the API is responding.
+          echo "Waiting for both merod admin APIs to come up..."
           for i in $(seq 1 30); do
-            CODE_1=$(curl -s -o /dev/null -w "%{http_code}" "${NODE_1_URL}/auth/login" || echo "000")
-            CODE_2=$(curl -s -o /dev/null -w "%{http_code}" "${NODE_2_URL}/auth/login" || echo "000")
+            CODE_1=$(curl -s -o /dev/null -w "%{http_code}" "${NODE_1_URL}/admin-api/contexts" || echo "000")
+            CODE_2=$(curl -s -o /dev/null -w "%{http_code}" "${NODE_2_URL}/admin-api/contexts" || echo "000")
             if [ "${CODE_1:0:1}" = "2" ] && [ "${CODE_2:0:1}" = "2" ]; then
-              echo "Both nodes routable (attempt ${i})  node1=${CODE_1} node2=${CODE_2}"
+              echo "Both nodes responding (attempt ${i})  node1=${CODE_1} node2=${CODE_2}"
               break
             fi
             if [ "$i" -eq 30 ]; then
-              echo "Nodes not routable after 60s  node1=${CODE_1} node2=${CODE_2}"
+              echo "Nodes not responding after 60s  node1=${CODE_1} node2=${CODE_2}"
               exit 1
             fi
             sleep 2
           done
 
-          # No -f: 4xx/5xx must not abort the script under `set -e`. We
-          # validate the JSON shape after each call so a meaningful error
-          # bubbles up instead of a silent exit.
-          mint_token() {
-            local node_url=$1
-            curl -sS -X POST "${node_url}/auth/token" \
-              -H "Content-Type: application/json" \
-              -d "{
-                \"auth_method\":  \"user_password\",
-                \"public_key\":   \"${ADMIN_USER}\",
-                \"client_name\":  \"battleships-integration-ci\",
-                \"timestamp\":    0,
-                \"permissions\":  [],
-                \"provider_data\": {\"username\": \"${ADMIN_USER}\", \"password\": \"${ADMIN_PASS}\"}
-              }"
-          }
-
-          echo "--- mint token (node 1) ---"
-          AUTH_1=$(mint_token "${NODE_1_URL}")
-          echo "$AUTH_1" | head -c 500; echo
-          echo "--- mint token (node 2) ---"
-          AUTH_2=$(mint_token "${NODE_2_URL}")
-          echo "$AUTH_2" | head -c 500; echo
-
-          ACCESS_TOKEN_1=$(echo "$AUTH_1" | jq -r '.data.access_token // empty')
-          REFRESH_TOKEN_1=$(echo "$AUTH_1" | jq -r '.data.refresh_token // empty')
-          ACCESS_TOKEN_2=$(echo "$AUTH_2" | jq -r '.data.access_token // empty')
-          REFRESH_TOKEN_2=$(echo "$AUTH_2" | jq -r '.data.refresh_token // empty')
-
-          [ -n "$ACCESS_TOKEN_1" ] || { echo "Node 1 auth failed: $AUTH_1"; exit 1; }
-          [ -n "$ACCESS_TOKEN_2" ] || { echo "Node 2 auth failed: $AUTH_2"; exit 1; }
-
           probe_admin() {
             local node_url=$1
             local path=$2
-            local token=$3
-            local code
             local body
             body=$(curl -sS -o /tmp/probe.body -w "%{http_code}" \
-              -H "Authorization: Bearer ${token}" \
               "${node_url}${path}")
-            code=$body
-            echo "GET ${node_url}${path} → HTTP ${code}" >&2
+            echo "GET ${node_url}${path} → HTTP ${body}" >&2
             head -c 400 /tmp/probe.body >&2; echo >&2
             cat /tmp/probe.body
           }
 
           echo "--- discover application ---"
-          APPS=$(probe_admin "${NODE_1_URL}" "/admin-api/applications" "${ACCESS_TOKEN_1}")
+          APPS=$(probe_admin "${NODE_1_URL}" "/admin-api/applications")
           APP_ID=$(echo "$APPS" | jq -r '.data.apps[0].id // empty')
 
           echo "--- discover namespace ---"
-          NS_RESP=$(probe_admin "${NODE_1_URL}" "/admin-api/namespaces" "${ACCESS_TOKEN_1}")
+          NS_RESP=$(probe_admin "${NODE_1_URL}" "/admin-api/namespaces")
           NS_ID=$(echo "$NS_RESP" | jq -r '.data[0].namespaceId // empty')
 
           echo "--- discover lobby context ---"
-          CTXS=$(probe_admin "${NODE_1_URL}" "/admin-api/contexts" "${ACCESS_TOKEN_1}")
+          CTXS=$(probe_admin "${NODE_1_URL}" "/admin-api/contexts")
           CTX_ID=$(echo "$CTXS" | jq -r '.data.contexts[0].id // empty')
 
           MEMBER_KEY_1=""
           MEMBER_KEY_2=""
           if [ -n "$CTX_ID" ]; then
             echo "--- discover member keys ---"
-            IDS_1=$(probe_admin "${NODE_1_URL}" "/admin-api/contexts/${CTX_ID}/identities-owned" "${ACCESS_TOKEN_1}")
+            IDS_1=$(probe_admin "${NODE_1_URL}" "/admin-api/contexts/${CTX_ID}/identities-owned")
             MEMBER_KEY_1=$(echo "$IDS_1" | jq -r '.data.identities[0] // empty')
 
-            IDS_2=$(probe_admin "${NODE_2_URL}" "/admin-api/contexts/${CTX_ID}/identities-owned" "${ACCESS_TOKEN_2}")
+            IDS_2=$(probe_admin "${NODE_2_URL}" "/admin-api/contexts/${CTX_ID}/identities-owned")
             MEMBER_KEY_2=$(echo "$IDS_2" | jq -r '.data.identities[0] // empty')
           fi
+
+          # Tokens are not required when auth_service is off — keep the
+          # vars empty; tests just won't write a Bearer header.
+          ACCESS_TOKEN_1=""
+          REFRESH_TOKEN_1=""
+          ACCESS_TOKEN_2=""
+          REFRESH_TOKEN_2=""
 
           [ -n "$APP_ID" ]       || { echo "Failed to discover application id"; exit 1; }
           [ -n "$NS_ID" ]        || { echo "Failed to discover namespace id";   exit 1; }

--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -68,11 +68,13 @@ jobs:
 
       - name: Install merobox
         run: |
-          python3 -m pip install --user --upgrade pip
-          python3 -m pip install --user \
-            "git+https://github.com/calimero-network/merobox.git@master"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/merobox" --version
+          curl -fsSL https://calimero-network.github.io/merobox/gpg.key \
+            | sudo tee /usr/share/keyrings/merobox.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/merobox.gpg] https://calimero-network.github.io/merobox stable main" \
+            | sudo tee /etc/apt/sources.list.d/merobox.list
+          sudo apt-get update
+          sudo apt-get install -y merobox
+          merobox --version
 
       # Run setup workflow (stop_all_nodes: false leaves nodes alive)
       - name: Run Battleships Integration Setup

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,9 @@ e2e/data/
 logic/data/
 
 .worktrees/
+
+# Playwright
+app/.env.integration
+app/playwright-report/
+app/test-results/
+app/e2e/.auth/

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ app/.env.integration
 app/playwright-report/
 app/test-results/
 app/e2e/.auth/
+
+# Claude Code session state
+.claude/

--- a/app/e2e/diagnostics.spec.ts
+++ b/app/e2e/diagnostics.spec.ts
@@ -19,7 +19,7 @@ test.describe('Diagnostics', () => {
       console.log(`[browser requestfailed] ${req.method()} ${req.url()} → ${req.failure()?.errorText}`);
     });
 
-    await bypassCors(page, env.node1.url);
+    await bypassCors(page, [{ nodeUrl: env.node1.url, accessToken: env.node1.accessToken }]);
     await injectMeroAuth(page, {
       nodeUrl: env.node1.url,
       accessToken: env.node1.accessToken,

--- a/app/e2e/diagnostics.spec.ts
+++ b/app/e2e/diagnostics.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * One-shot diagnostics — runs first, dumps the auth/network surface so we
+ * can see why MeroProvider is failing to mark the session authenticated.
+ */
+
+import { test, expect } from '@playwright/test';
+import { envAvailable, getEnv } from './helpers/rpc-client';
+import { injectMeroAuth } from './helpers/node-client';
+
+test.describe('Diagnostics', () => {
+  test.skip(!envAvailable(), 'integration env not available');
+
+  test('auth tokens reach the merod admin API from the browser', async ({ page }) => {
+    const env = getEnv();
+
+    page.on('console', (msg) => console.log(`[browser ${msg.type()}] ${msg.text()}`));
+    page.on('pageerror', (err) => console.log(`[browser pageerror] ${err.message}`));
+    page.on('requestfailed', (req) => {
+      console.log(`[browser requestfailed] ${req.method()} ${req.url()} → ${req.failure()?.errorText}`);
+    });
+
+    await injectMeroAuth(page, {
+      nodeUrl: env.node1.url,
+      accessToken: env.node1.accessToken,
+      refreshToken: env.node1.refreshToken,
+      applicationId: env.applicationId,
+      namespaceId: env.namespaceId,
+      lobbyContextId: env.lobbyContextId,
+      memberKey: env.node1.memberKey,
+    });
+
+    await page.goto('/');
+
+    const ls = await page.evaluate(() => {
+      const out: Record<string, string | null> = {};
+      for (const k of [
+        'mero:access_token',
+        'mero:refresh_token',
+        'mero:expires_at',
+        'mero:node_url',
+        'mero:application_id',
+        'mero:context_id',
+        'mero:context_identity',
+        'battleships:selectedNamespaceId',
+      ]) {
+        const v = localStorage.getItem(k);
+        out[k] = v ? `${v.slice(0, 24)}…(len=${v.length})` : null;
+      }
+      return out;
+    });
+    console.log('localStorage:', JSON.stringify(ls, null, 2));
+
+    const result = await page.evaluate(async (cfg) => {
+      try {
+        const headers = { Authorization: `Bearer ${cfg.token}` };
+        const r = await fetch(`${cfg.nodeUrl}/admin-api/contexts`, { headers });
+        const text = await r.text();
+        return {
+          ok: r.ok,
+          status: r.status,
+          statusText: r.statusText,
+          body: text.slice(0, 400),
+        };
+      } catch (e) {
+        return { error: e instanceof Error ? `${e.name}: ${e.message}` : String(e) };
+      }
+    }, { nodeUrl: env.node1.url, token: env.node1.accessToken });
+    console.log('fetch /admin-api/contexts result:', JSON.stringify(result, null, 2));
+
+    expect(result, 'expected the browser to reach /admin-api/contexts').toMatchObject({ ok: true });
+  });
+});

--- a/app/e2e/diagnostics.spec.ts
+++ b/app/e2e/diagnostics.spec.ts
@@ -34,8 +34,7 @@ test.describe('Diagnostics', () => {
     const ls = await page.evaluate(() => {
       const out: Record<string, string | null> = {};
       for (const k of [
-        'mero:access_token',
-        'mero:refresh_token',
+        'mero-tokens',
         'mero:expires_at',
         'mero:node_url',
         'mero:application_id',

--- a/app/e2e/diagnostics.spec.ts
+++ b/app/e2e/diagnostics.spec.ts
@@ -5,7 +5,7 @@
 
 import { test, expect } from '@playwright/test';
 import { envAvailable, getEnv } from './helpers/rpc-client';
-import { injectMeroAuth } from './helpers/node-client';
+import { bypassCors, injectMeroAuth } from './helpers/node-client';
 
 test.describe('Diagnostics', () => {
   test.skip(!envAvailable(), 'integration env not available');
@@ -19,6 +19,7 @@ test.describe('Diagnostics', () => {
       console.log(`[browser requestfailed] ${req.method()} ${req.url()} → ${req.failure()?.errorText}`);
     });
 
+    await bypassCors(page, env.node1.url);
     await injectMeroAuth(page, {
       nodeUrl: env.node1.url,
       accessToken: env.node1.accessToken,

--- a/app/e2e/diagnostics.spec.ts
+++ b/app/e2e/diagnostics.spec.ts
@@ -5,7 +5,7 @@
 
 import { test, expect } from '@playwright/test';
 import { envAvailable, getEnv } from './helpers/rpc-client';
-import { bypassCors, injectMeroAuth } from './helpers/node-client';
+import { injectMeroAuth } from './helpers/node-client';
 
 test.describe('Diagnostics', () => {
   test.skip(!envAvailable(), 'integration env not available');
@@ -19,7 +19,6 @@ test.describe('Diagnostics', () => {
       console.log(`[browser requestfailed] ${req.method()} ${req.url()} → ${req.failure()?.errorText}`);
     });
 
-    await bypassCors(page, [{ nodeUrl: env.node1.url, accessToken: env.node1.accessToken }]);
     await injectMeroAuth(page, {
       nodeUrl: env.node1.url,
       accessToken: env.node1.accessToken,

--- a/app/e2e/global-setup.ts
+++ b/app/e2e/global-setup.ts
@@ -1,0 +1,44 @@
+/**
+ * Playwright global setup.
+ *
+ * Loads app/.env.integration into process.env so workers can read E2E_* vars
+ * via getEnv() without per-test plumbing. The file is written by the
+ * integration-ci.yml job after merobox boots two nodes and credentials are
+ * minted; running the suite locally without it is fine — every integration
+ * spec calls envAvailable() and skips when the file is absent.
+ *
+ * INTEGRATION_MODE=true (set by ci) tells this hook there is no browser-driven
+ * auth flow to run; tokens are injected per-test via injectMeroAuth.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import type { FullConfig } from '@playwright/test';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default async function globalSetup(_config: FullConfig): Promise<void> {
+  const envPath = path.join(__dirname, '..', '.env.integration');
+  if (!fs.existsSync(envPath)) {
+    if (process.env.INTEGRATION_MODE === 'true') {
+      throw new Error(
+        `INTEGRATION_MODE=true but ${envPath} is missing — ` +
+          'check the auth-bootstrap step in integration-ci.yml',
+      );
+    }
+    return;
+  }
+  for (const line of fs.readFileSync(envPath, 'utf-8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq < 1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const val = trimmed.slice(eq + 1).trim();
+    if (key && !(key in process.env)) {
+      process.env[key] = val;
+    }
+  }
+}

--- a/app/e2e/helpers/node-client.ts
+++ b/app/e2e/helpers/node-client.ts
@@ -69,11 +69,17 @@ export async function bypassCors(
         return;
       }
 
-      const headers = {
-        ...req.headers(),
-        authorization: `Bearer ${accessToken}`,
-      };
-      const response = await route.fetch({ headers });
+      // Strip browser-set headers that confuse Traefik's routing/CORS
+      // (Origin, Referer) and any auth-bearing headers we'll re-set ourselves.
+      const original = req.headers();
+      const filtered: Record<string, string> = {};
+      for (const [k, v] of Object.entries(original)) {
+        const lk = k.toLowerCase();
+        if (lk === 'origin' || lk === 'referer' || lk === 'authorization') continue;
+        filtered[k] = v;
+      }
+      filtered['authorization'] = `Bearer ${accessToken}`;
+      const response = await route.fetch({ headers: filtered });
       const respHeaders = {
         ...response.headers(),
         'access-control-allow-origin': allowOrigin,

--- a/app/e2e/helpers/node-client.ts
+++ b/app/e2e/helpers/node-client.ts
@@ -1,0 +1,33 @@
+/**
+ * Writes the mero-react v2 storage keys directly so tests skip the
+ * ConnectButton → auth-frontend → callback flow.
+ *
+ * Also seeds battleships:selectedNamespaceId so the LobbySelect picker
+ * auto-selects the seeded lobby instead of waiting on the user.
+ */
+
+import type { Page } from '@playwright/test';
+
+export interface InjectAuthOptions {
+  nodeUrl: string;
+  accessToken: string;
+  refreshToken: string;
+  applicationId: string;
+  namespaceId: string;
+  lobbyContextId: string;
+  memberKey: string;
+}
+
+export async function injectMeroAuth(page: Page, opts: InjectAuthOptions): Promise<void> {
+  await page.addInitScript((data) => {
+    const expiresAt = String(Date.now() + 3_600_000);
+    localStorage.setItem('mero:access_token', data.accessToken);
+    localStorage.setItem('mero:refresh_token', data.refreshToken);
+    localStorage.setItem('mero:expires_at', expiresAt);
+    localStorage.setItem('mero:node_url', data.nodeUrl);
+    localStorage.setItem('mero:application_id', data.applicationId);
+    localStorage.setItem('mero:context_id', data.lobbyContextId);
+    localStorage.setItem('mero:context_identity', data.memberKey);
+    localStorage.setItem('battleships:selectedNamespaceId', data.namespaceId);
+  }, opts);
+}

--- a/app/e2e/helpers/node-client.ts
+++ b/app/e2e/helpers/node-client.ts
@@ -6,7 +6,7 @@
  * auto-selects the seeded lobby instead of waiting on the user.
  */
 
-import type { Page } from '@playwright/test';
+import type { BrowserContext, Page, Route } from '@playwright/test';
 
 export interface InjectAuthOptions {
   nodeUrl: string;
@@ -30,4 +30,48 @@ export async function injectMeroAuth(page: Page, opts: InjectAuthOptions): Promi
     localStorage.setItem('mero:context_identity', data.memberKey);
     localStorage.setItem('battleships:selectedNamespaceId', data.namespaceId);
   }, opts);
+}
+
+/**
+ * Installs a route handler that injects CORS headers onto every response from
+ * the merod node, and short-circuits OPTIONS preflights with a permissive 204.
+ *
+ * Required because Traefik's forward-auth middleware on the integration stack
+ * rejects unauthenticated OPTIONS preflights, stripping the Access-Control-*
+ * headers — without this, the browser blocks every cross-origin admin-api
+ * fetch from the Vite dev server origin.
+ */
+export async function bypassCors(target: BrowserContext | Page, ...nodeUrls: string[]): Promise<void> {
+  const hosts = nodeUrls.map((u) => new URL(u).host);
+  for (const host of hosts) {
+    await target.route(`http://${host}/**`, async (route: Route) => {
+      const req = route.request();
+      const origin = req.headerValue('origin');
+      const allowOrigin = (await origin) ?? '*';
+
+      if (req.method() === 'OPTIONS') {
+        await route.fulfill({
+          status: 204,
+          headers: {
+            'access-control-allow-origin': allowOrigin,
+            'access-control-allow-credentials': 'true',
+            'access-control-allow-methods': 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
+            'access-control-allow-headers':
+              'Authorization,Content-Type,Accept,X-Requested-With,X-Auth-Token,Cache-Control',
+            'access-control-max-age': '600',
+          },
+        });
+        return;
+      }
+
+      const response = await route.fetch();
+      const headers = {
+        ...response.headers(),
+        'access-control-allow-origin': allowOrigin,
+        'access-control-allow-credentials': 'true',
+        'access-control-expose-headers': 'X-Auth-Error,Content-Length',
+      };
+      await route.fulfill({ response, headers });
+    });
+  }
 }

--- a/app/e2e/helpers/node-client.ts
+++ b/app/e2e/helpers/node-client.ts
@@ -33,21 +33,26 @@ export async function injectMeroAuth(page: Page, opts: InjectAuthOptions): Promi
 }
 
 /**
- * Installs a route handler that injects CORS headers onto every response from
- * the merod node, and short-circuits OPTIONS preflights with a permissive 204.
+ * Route handler that turns every cross-origin merod request into something the
+ * browser will accept, and re-injects the Bearer token server-side because
+ * Chromium drops the Authorization header on cross-origin fetches whose
+ * preflight didn't fully succeed (which is our case — Traefik's forward-auth
+ * middleware kills the OPTIONS preflight before CORS headers attach).
  *
- * Required because Traefik's forward-auth middleware on the integration stack
- * rejects unauthenticated OPTIONS preflights, stripping the Access-Control-*
- * headers — without this, the browser blocks every cross-origin admin-api
- * fetch from the Vite dev server origin.
+ * - OPTIONS preflights are short-circuited with a permissive 204.
+ * - Real requests are re-issued from Node with `Authorization: Bearer <token>`
+ *   forced, then the response is overlaid with Access-Control-Allow-Origin so
+ *   the browser does not reject it.
  */
-export async function bypassCors(target: BrowserContext | Page, ...nodeUrls: string[]): Promise<void> {
-  const hosts = nodeUrls.map((u) => new URL(u).host);
-  for (const host of hosts) {
+export async function bypassCors(
+  target: BrowserContext | Page,
+  bindings: ReadonlyArray<{ nodeUrl: string; accessToken: string }>,
+): Promise<void> {
+  for (const { nodeUrl, accessToken } of bindings) {
+    const host = new URL(nodeUrl).host;
     await target.route(`http://${host}/**`, async (route: Route) => {
       const req = route.request();
-      const origin = req.headerValue('origin');
-      const allowOrigin = (await origin) ?? '*';
+      const allowOrigin = (await req.headerValue('origin')) ?? '*';
 
       if (req.method() === 'OPTIONS') {
         await route.fulfill({
@@ -64,14 +69,18 @@ export async function bypassCors(target: BrowserContext | Page, ...nodeUrls: str
         return;
       }
 
-      const response = await route.fetch();
       const headers = {
+        ...req.headers(),
+        authorization: `Bearer ${accessToken}`,
+      };
+      const response = await route.fetch({ headers });
+      const respHeaders = {
         ...response.headers(),
         'access-control-allow-origin': allowOrigin,
         'access-control-allow-credentials': 'true',
         'access-control-expose-headers': 'X-Auth-Error,Content-Length',
       };
-      await route.fulfill({ response, headers });
+      await route.fulfill({ response, headers: respHeaders });
     });
   }
 }

--- a/app/e2e/helpers/node-client.ts
+++ b/app/e2e/helpers/node-client.ts
@@ -6,7 +6,7 @@
  * auto-selects the seeded lobby instead of waiting on the user.
  */
 
-import type { Page } from '@playwright/test';
+import type { BrowserContext, Page } from '@playwright/test';
 
 export interface InjectAuthOptions {
   nodeUrl: string;
@@ -18,8 +18,12 @@ export interface InjectAuthOptions {
   memberKey: string;
 }
 
-export async function injectMeroAuth(page: Page, opts: InjectAuthOptions): Promise<void> {
-  await page.addInitScript((data) => {
+// Page and BrowserContext both expose addInitScript; tests that open multiple
+// pages per node share their auth at the context level.
+type InitScriptTarget = Pick<Page, 'addInitScript'> | Pick<BrowserContext, 'addInitScript'>;
+
+export async function injectMeroAuth(target: InitScriptTarget, opts: InjectAuthOptions): Promise<void> {
+  await target.addInitScript((data) => {
     const expiresAt = Date.now() + 3_600_000;
     // mero-js's LocalStorageTokenStore (the one MeroProvider actually uses)
     // stores a single JSON blob under 'mero-tokens'. The namespaced

--- a/app/e2e/helpers/node-client.ts
+++ b/app/e2e/helpers/node-client.ts
@@ -6,7 +6,7 @@
  * auto-selects the seeded lobby instead of waiting on the user.
  */
 
-import type { BrowserContext, Page, Route } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 export interface InjectAuthOptions {
   nodeUrl: string;
@@ -32,73 +32,3 @@ export async function injectMeroAuth(page: Page, opts: InjectAuthOptions): Promi
   }, opts);
 }
 
-/**
- * Route handler that turns every cross-origin merod request into something the
- * browser will accept, and re-injects the Bearer token server-side because
- * Chromium drops the Authorization header on cross-origin fetches whose
- * preflight didn't fully succeed (which is our case — Traefik's forward-auth
- * middleware kills the OPTIONS preflight before CORS headers attach).
- *
- * - OPTIONS preflights are short-circuited with a permissive 204.
- * - Real requests are re-issued from Node with `Authorization: Bearer <token>`
- *   forced, then the response is overlaid with Access-Control-Allow-Origin so
- *   the browser does not reject it.
- */
-export async function bypassCors(
-  target: BrowserContext | Page,
-  bindings: ReadonlyArray<{ nodeUrl: string; accessToken: string }>,
-): Promise<void> {
-  for (const { nodeUrl, accessToken } of bindings) {
-    const host = new URL(nodeUrl).host;
-    await target.route(`http://${host}/**`, async (route: Route) => {
-      const req = route.request();
-      const allowOrigin = (await req.headerValue('origin')) ?? '*';
-
-      if (req.method() === 'OPTIONS') {
-        await route.fulfill({
-          status: 204,
-          headers: {
-            'access-control-allow-origin': allowOrigin,
-            'access-control-allow-credentials': 'true',
-            'access-control-allow-methods': 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
-            'access-control-allow-headers':
-              'Authorization,Content-Type,Accept,X-Requested-With,X-Auth-Token,Cache-Control',
-            'access-control-max-age': '600',
-          },
-        });
-        return;
-      }
-
-      // Re-issue with Node's native fetch so we have full control over what
-      // headers go out — Playwright's route.fetch was forwarding browser
-      // header state that made Traefik 404 the request.
-      const outHeaders: Record<string, string> = {
-        accept: 'application/json',
-        authorization: `Bearer ${accessToken}`,
-      };
-      const ct = await req.headerValue('content-type');
-      if (ct) outHeaders['content-type'] = ct;
-
-      const init: RequestInit = { method: req.method(), headers: outHeaders };
-      const postBuf = req.postDataBuffer();
-      if (postBuf) (init as { body: Buffer }).body = postBuf;
-
-      console.log('[route] fwd', req.method(), req.url());
-      const r = await fetch(req.url(), init);
-      const body = Buffer.from(await r.arrayBuffer());
-      console.log('[route] resp', r.status, 'len=', body.length);
-
-      const respHeaders: Record<string, string> = {
-        'access-control-allow-origin': allowOrigin,
-        'access-control-allow-credentials': 'true',
-        'access-control-expose-headers': 'X-Auth-Error,Content-Length',
-      };
-      r.headers.forEach((v, k) => {
-        if (k.toLowerCase().startsWith('access-control-')) return;
-        respHeaders[k] = v;
-      });
-
-      await route.fulfill({ status: r.status, headers: respHeaders, body });
-    });
-  }
-}

--- a/app/e2e/helpers/node-client.ts
+++ b/app/e2e/helpers/node-client.ts
@@ -69,24 +69,36 @@ export async function bypassCors(
         return;
       }
 
-      // Strip browser-set headers that confuse Traefik's routing/CORS
-      // (Origin, Referer) and any auth-bearing headers we'll re-set ourselves.
-      const original = req.headers();
-      const filtered: Record<string, string> = {};
-      for (const [k, v] of Object.entries(original)) {
-        const lk = k.toLowerCase();
-        if (lk === 'origin' || lk === 'referer' || lk === 'authorization') continue;
-        filtered[k] = v;
-      }
-      filtered['authorization'] = `Bearer ${accessToken}`;
-      const response = await route.fetch({ headers: filtered });
-      const respHeaders = {
-        ...response.headers(),
+      // Re-issue with Node's native fetch so we have full control over what
+      // headers go out — Playwright's route.fetch was forwarding browser
+      // header state that made Traefik 404 the request.
+      const outHeaders: Record<string, string> = {
+        accept: 'application/json',
+        authorization: `Bearer ${accessToken}`,
+      };
+      const ct = await req.headerValue('content-type');
+      if (ct) outHeaders['content-type'] = ct;
+
+      const init: RequestInit = { method: req.method(), headers: outHeaders };
+      const postBuf = req.postDataBuffer();
+      if (postBuf) (init as { body: Buffer }).body = postBuf;
+
+      console.log('[route] fwd', req.method(), req.url());
+      const r = await fetch(req.url(), init);
+      const body = Buffer.from(await r.arrayBuffer());
+      console.log('[route] resp', r.status, 'len=', body.length);
+
+      const respHeaders: Record<string, string> = {
         'access-control-allow-origin': allowOrigin,
         'access-control-allow-credentials': 'true',
         'access-control-expose-headers': 'X-Auth-Error,Content-Length',
       };
-      await route.fulfill({ response, headers: respHeaders });
+      r.headers.forEach((v, k) => {
+        if (k.toLowerCase().startsWith('access-control-')) return;
+        respHeaders[k] = v;
+      });
+
+      await route.fulfill({ status: r.status, headers: respHeaders, body });
     });
   }
 }

--- a/app/e2e/helpers/node-client.ts
+++ b/app/e2e/helpers/node-client.ts
@@ -20,10 +20,20 @@ export interface InjectAuthOptions {
 
 export async function injectMeroAuth(page: Page, opts: InjectAuthOptions): Promise<void> {
   await page.addInitScript((data) => {
-    const expiresAt = String(Date.now() + 3_600_000);
-    localStorage.setItem('mero:access_token', data.accessToken);
-    localStorage.setItem('mero:refresh_token', data.refreshToken);
-    localStorage.setItem('mero:expires_at', expiresAt);
+    const expiresAt = Date.now() + 3_600_000;
+    // mero-js's LocalStorageTokenStore (the one MeroProvider actually uses)
+    // stores a single JSON blob under 'mero-tokens'. The namespaced
+    // 'mero:access_token' / 'mero:refresh_token' keys exported by
+    // mero-react/storage are unused for the token itself, so writing only
+    // those leaves MeroProvider's first /admin-api/contexts call unauthed.
+    localStorage.setItem('mero-tokens', JSON.stringify({
+      access_token: data.accessToken,
+      refresh_token: data.refreshToken,
+      expires_at: expiresAt,
+    }));
+    // The non-token mero-react state (node URL, ids) does use the
+    // namespaced keys.
+    localStorage.setItem('mero:expires_at', String(expiresAt));
     localStorage.setItem('mero:node_url', data.nodeUrl);
     localStorage.setItem('mero:application_id', data.applicationId);
     localStorage.setItem('mero:context_id', data.lobbyContextId);

--- a/app/e2e/helpers/rpc-client.ts
+++ b/app/e2e/helpers/rpc-client.ts
@@ -19,15 +19,17 @@ export interface NodeEnv {
   memberKey: string;
 }
 
-// Tokens are optional: when merobox runs without auth_service, the merod
-// admin API is unauthenticated and tests don't need a Bearer header.
 const REQUIRED_KEYS = [
   'E2E_APPLICATION_ID',
   'E2E_NAMESPACE_ID',
   'E2E_LOBBY_CONTEXT_ID',
   'E2E_NODE_URL',
+  'E2E_ACCESS_TOKEN',
+  'E2E_REFRESH_TOKEN',
   'E2E_MEMBER_KEY',
   'E2E_NODE_URL_2',
+  'E2E_ACCESS_TOKEN_2',
+  'E2E_REFRESH_TOKEN_2',
   'E2E_MEMBER_KEY_2',
 ] as const;
 
@@ -47,14 +49,14 @@ export function getEnv(): IntegrationEnv {
     lobbyContextId: process.env.E2E_LOBBY_CONTEXT_ID!,
     node1: {
       url: process.env.E2E_NODE_URL!,
-      accessToken: process.env.E2E_ACCESS_TOKEN ?? '',
-      refreshToken: process.env.E2E_REFRESH_TOKEN ?? '',
+      accessToken: process.env.E2E_ACCESS_TOKEN!,
+      refreshToken: process.env.E2E_REFRESH_TOKEN!,
       memberKey: process.env.E2E_MEMBER_KEY!,
     },
     node2: {
       url: process.env.E2E_NODE_URL_2!,
-      accessToken: process.env.E2E_ACCESS_TOKEN_2 ?? '',
-      refreshToken: process.env.E2E_REFRESH_TOKEN_2 ?? '',
+      accessToken: process.env.E2E_ACCESS_TOKEN_2!,
+      refreshToken: process.env.E2E_REFRESH_TOKEN_2!,
       memberKey: process.env.E2E_MEMBER_KEY_2!,
     },
   };

--- a/app/e2e/helpers/rpc-client.ts
+++ b/app/e2e/helpers/rpc-client.ts
@@ -19,17 +19,15 @@ export interface NodeEnv {
   memberKey: string;
 }
 
+// Tokens are optional: when merobox runs without auth_service, the merod
+// admin API is unauthenticated and tests don't need a Bearer header.
 const REQUIRED_KEYS = [
   'E2E_APPLICATION_ID',
   'E2E_NAMESPACE_ID',
   'E2E_LOBBY_CONTEXT_ID',
   'E2E_NODE_URL',
-  'E2E_ACCESS_TOKEN',
-  'E2E_REFRESH_TOKEN',
   'E2E_MEMBER_KEY',
   'E2E_NODE_URL_2',
-  'E2E_ACCESS_TOKEN_2',
-  'E2E_REFRESH_TOKEN_2',
   'E2E_MEMBER_KEY_2',
 ] as const;
 
@@ -49,14 +47,14 @@ export function getEnv(): IntegrationEnv {
     lobbyContextId: process.env.E2E_LOBBY_CONTEXT_ID!,
     node1: {
       url: process.env.E2E_NODE_URL!,
-      accessToken: process.env.E2E_ACCESS_TOKEN!,
-      refreshToken: process.env.E2E_REFRESH_TOKEN!,
+      accessToken: process.env.E2E_ACCESS_TOKEN ?? '',
+      refreshToken: process.env.E2E_REFRESH_TOKEN ?? '',
       memberKey: process.env.E2E_MEMBER_KEY!,
     },
     node2: {
       url: process.env.E2E_NODE_URL_2!,
-      accessToken: process.env.E2E_ACCESS_TOKEN_2!,
-      refreshToken: process.env.E2E_REFRESH_TOKEN_2!,
+      accessToken: process.env.E2E_ACCESS_TOKEN_2 ?? '',
+      refreshToken: process.env.E2E_REFRESH_TOKEN_2 ?? '',
       memberKey: process.env.E2E_MEMBER_KEY_2!,
     },
   };

--- a/app/e2e/helpers/rpc-client.ts
+++ b/app/e2e/helpers/rpc-client.ts
@@ -1,0 +1,63 @@
+/**
+ * Reads the integration env that ci writes to app/.env.integration.
+ * Specs use envAvailable() to skip gracefully when the file is absent
+ * (i.e. when running outside a live-merod CI job).
+ */
+
+export interface IntegrationEnv {
+  applicationId: string;
+  namespaceId: string;
+  lobbyContextId: string;
+  node1: NodeEnv;
+  node2: NodeEnv;
+}
+
+export interface NodeEnv {
+  url: string;
+  accessToken: string;
+  refreshToken: string;
+  memberKey: string;
+}
+
+const REQUIRED_KEYS = [
+  'E2E_APPLICATION_ID',
+  'E2E_NAMESPACE_ID',
+  'E2E_LOBBY_CONTEXT_ID',
+  'E2E_NODE_URL',
+  'E2E_ACCESS_TOKEN',
+  'E2E_REFRESH_TOKEN',
+  'E2E_MEMBER_KEY',
+  'E2E_NODE_URL_2',
+  'E2E_ACCESS_TOKEN_2',
+  'E2E_REFRESH_TOKEN_2',
+  'E2E_MEMBER_KEY_2',
+] as const;
+
+export function envAvailable(): boolean {
+  return REQUIRED_KEYS.every((k) => Boolean(process.env[k]));
+}
+
+export function getEnv(): IntegrationEnv {
+  for (const k of REQUIRED_KEYS) {
+    if (!process.env[k]) {
+      throw new Error(`Missing integration env var: ${k}`);
+    }
+  }
+  return {
+    applicationId: process.env.E2E_APPLICATION_ID!,
+    namespaceId: process.env.E2E_NAMESPACE_ID!,
+    lobbyContextId: process.env.E2E_LOBBY_CONTEXT_ID!,
+    node1: {
+      url: process.env.E2E_NODE_URL!,
+      accessToken: process.env.E2E_ACCESS_TOKEN!,
+      refreshToken: process.env.E2E_REFRESH_TOKEN!,
+      memberKey: process.env.E2E_MEMBER_KEY!,
+    },
+    node2: {
+      url: process.env.E2E_NODE_URL_2!,
+      accessToken: process.env.E2E_ACCESS_TOKEN_2!,
+      refreshToken: process.env.E2E_REFRESH_TOKEN_2!,
+      memberKey: process.env.E2E_MEMBER_KEY_2!,
+    },
+  };
+}

--- a/app/e2e/landing.spec.ts
+++ b/app/e2e/landing.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Landing surface — runs without a live merod node.
+ *
+ * Verifies the unauthenticated entry point renders the expected branding,
+ * the ConnectButton is present, and protected routes redirect back to '/'
+ * (which is itself the login surface — Authenticate.tsx is mounted there).
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Landing (unauthenticated)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    // Wait for Vite's first-request compile + MeroProvider init to settle.
+    await expect(page.getByText('Battleships').first()).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+
+  test('shows the Battleships title', async ({ page }) => {
+    await expect(page.getByText('Battleships').first()).toBeVisible();
+  });
+
+  test('shows the demo description', async ({ page }) => {
+    await expect(
+      page.getByText(/fully decentralized battleships game/i),
+    ).toBeVisible();
+  });
+
+  test('renders feature bullets', async ({ page }) => {
+    await expect(page.getByText(/Private ship placement/i)).toBeVisible();
+    await expect(page.getByText(/Verifiable shots/i)).toBeVisible();
+    await expect(page.getByText(/Real-time P2P state sync/i)).toBeVisible();
+  });
+
+  test('shows a Connect button', async ({ page }) => {
+    // ConnectButton from mero-react renders a button with "Connect" text.
+    await expect(
+      page.getByRole('button', { name: /connect/i }).first(),
+    ).toBeVisible();
+  });
+
+  test('renders external-link buttons', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Docs' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'GitHub' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Calimero' })).toBeVisible();
+  });
+
+  test('unknown routes redirect to /', async ({ page }) => {
+    await page.goto('/nonexistent-path');
+    await expect(page).toHaveURL(/\/$/, { timeout: 15_000 });
+    await expect(page.getByText('Battleships').first()).toBeVisible();
+  });
+
+  test('protected /lobby route requires auth', async ({ page }) => {
+    // Without injected tokens the page either redirects to '/' or stays on
+    // /lobby but renders the auth prompt — either way the ConnectButton is
+    // visible and gameplay UI is not.
+    await page.goto('/lobby');
+    await expect(
+      page.getByRole('button', { name: /connect/i }).first(),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/app/e2e/lobby.spec.ts
+++ b/app/e2e/lobby.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Single-player lobby surface against a live merod node.
+ *
+ * Injects node-1 auth + the seeded namespace into localStorage, navigates to
+ * /lobby?id=<NS>, and asserts the lobby renders with both members online.
+ */
+
+import { test, expect } from '@playwright/test';
+import { envAvailable, getEnv } from './helpers/rpc-client';
+import { injectMeroAuth } from './helpers/node-client';
+
+test.describe('Lobby (integration)', () => {
+  test.beforeEach(async ({ page }) => {
+    if (!envAvailable()) test.skip();
+    const env = getEnv();
+    await injectMeroAuth(page, {
+      nodeUrl: env.node1.url,
+      accessToken: env.node1.accessToken,
+      refreshToken: env.node1.refreshToken,
+      applicationId: env.applicationId,
+      namespaceId: env.namespaceId,
+      lobbyContextId: env.lobbyContextId,
+      memberKey: env.node1.memberKey,
+    });
+  });
+
+  test('renders the lobby with both members online', async ({ page }) => {
+    const env = getEnv();
+    await page.goto(`/lobby?id=${encodeURIComponent(env.namespaceId)}`);
+    await expect(page.getByText('Lobby').first()).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(/2 members online/i)).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('opens the members list and shows the self marker', async ({ page }) => {
+    const env = getEnv();
+    await page.goto(`/lobby?id=${encodeURIComponent(env.namespaceId)}`);
+    await expect(page.getByText(/2 members online/i)).toBeVisible({ timeout: 30_000 });
+
+    const summary = page.getByRole('group').getByText('Members').or(page.locator('summary', { hasText: 'Members' })).first();
+    await summary.click();
+    await expect(page.getByText('(you)')).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('exposes the executor key with a copy affordance', async ({ page }) => {
+    const env = getEnv();
+    await page.goto(`/lobby?id=${encodeURIComponent(env.namespaceId)}`);
+    await expect(page.getByText('Your Key')).toBeVisible({ timeout: 30_000 });
+    // Truncated key uses ellipsis: first 12 chars … last 8.
+    const head = env.node1.memberKey.slice(0, 12);
+    await expect(page.getByText(new RegExp(`^${escapeRegex(head)}\\.\\.\\.`))).toBeVisible();
+  });
+
+  test('renders the New Match form', async ({ page }) => {
+    const env = getEnv();
+    await page.goto(`/lobby?id=${encodeURIComponent(env.namespaceId)}`);
+    await expect(
+      page.getByPlaceholder(/Opponent's executor public key/i),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByRole('button', { name: 'Challenge' })).toBeVisible();
+  });
+});
+
+test.describe('Lobby Picker (integration)', () => {
+  test.beforeEach(async ({ page }) => {
+    if (!envAvailable()) test.skip();
+    const env = getEnv();
+    await injectMeroAuth(page, {
+      nodeUrl: env.node1.url,
+      accessToken: env.node1.accessToken,
+      refreshToken: env.node1.refreshToken,
+      applicationId: env.applicationId,
+      namespaceId: env.namespaceId,
+      lobbyContextId: env.lobbyContextId,
+      memberKey: env.node1.memberKey,
+    });
+  });
+
+  test('lists the seeded lobby and switches to cards view', async ({ page }) => {
+    // Bare /lobby (no ?id=) keeps the picker visible instead of auto-entering.
+    await page.goto('/lobby');
+    await expect(page.getByText('Add a Lobby')).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator('.lobby-row').first()).toBeVisible({ timeout: 30_000 });
+
+    await page.getByRole('button', { name: /cards/i }).click();
+    await expect(page.locator('.lobby-grid')).toBeVisible();
+  });
+
+  test('swaps between Create new and Join via invitation tabs', async ({ page }) => {
+    await page.goto('/lobby');
+    await expect(page.getByText('Add a Lobby')).toBeVisible({ timeout: 30_000 });
+
+    await expect(page.getByPlaceholder(/Lobby name/i)).toBeVisible();
+
+    await page.getByRole('tab', { name: /Join via invitation/i }).click();
+    await expect(page.getByPlaceholder(/Paste invitation/i)).toBeVisible({ timeout: 5_000 });
+
+    await page.getByRole('tab', { name: /Create new/i }).click();
+    await expect(page.getByPlaceholder(/Lobby name/i)).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('info icon is keyboard-focusable with an aria label', async ({ page }) => {
+    await page.goto('/lobby');
+    const infoIcon = page.locator('.info-icon').first();
+    await expect(infoIcon).toBeVisible({ timeout: 30_000 });
+    await expect(infoIcon).toHaveAttribute('aria-label', /lobby/i);
+    await infoIcon.focus();
+    await expect(infoIcon).toBeFocused();
+  });
+});
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/app/e2e/lobby.spec.ts
+++ b/app/e2e/lobby.spec.ts
@@ -13,7 +13,7 @@ test.describe('Lobby (integration)', () => {
   test.beforeEach(async ({ page }) => {
     if (!envAvailable()) test.skip();
     const env = getEnv();
-    await bypassCors(page, env.node1.url);
+    await bypassCors(page, [{ nodeUrl: env.node1.url, accessToken: env.node1.accessToken }]);
     await injectMeroAuth(page, {
       nodeUrl: env.node1.url,
       accessToken: env.node1.accessToken,
@@ -65,7 +65,7 @@ test.describe('Lobby Picker (integration)', () => {
   test.beforeEach(async ({ page }) => {
     if (!envAvailable()) test.skip();
     const env = getEnv();
-    await bypassCors(page, env.node1.url);
+    await bypassCors(page, [{ nodeUrl: env.node1.url, accessToken: env.node1.accessToken }]);
     await injectMeroAuth(page, {
       nodeUrl: env.node1.url,
       accessToken: env.node1.accessToken,

--- a/app/e2e/lobby.spec.ts
+++ b/app/e2e/lobby.spec.ts
@@ -7,12 +7,13 @@
 
 import { test, expect } from '@playwright/test';
 import { envAvailable, getEnv } from './helpers/rpc-client';
-import { injectMeroAuth } from './helpers/node-client';
+import { bypassCors, injectMeroAuth } from './helpers/node-client';
 
 test.describe('Lobby (integration)', () => {
   test.beforeEach(async ({ page }) => {
     if (!envAvailable()) test.skip();
     const env = getEnv();
+    await bypassCors(page, env.node1.url);
     await injectMeroAuth(page, {
       nodeUrl: env.node1.url,
       accessToken: env.node1.accessToken,
@@ -64,6 +65,7 @@ test.describe('Lobby Picker (integration)', () => {
   test.beforeEach(async ({ page }) => {
     if (!envAvailable()) test.skip();
     const env = getEnv();
+    await bypassCors(page, env.node1.url);
     await injectMeroAuth(page, {
       nodeUrl: env.node1.url,
       accessToken: env.node1.accessToken,

--- a/app/e2e/lobby.spec.ts
+++ b/app/e2e/lobby.spec.ts
@@ -82,7 +82,7 @@ test.describe('Lobby Picker (integration)', () => {
   test('lists the seeded lobby and switches to cards view', async ({ page }) => {
     // Bare /lobby (no ?id=) keeps the picker visible instead of auto-entering.
     await page.goto('/lobby');
-    await expect(page.getByText('Add a Lobby')).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator('.naval-card-title', { hasText: 'Add a Lobby' })).toBeVisible({ timeout: 30_000 });
     await expect(page.locator('.lobby-row').first()).toBeVisible({ timeout: 30_000 });
 
     await page.getByRole('button', { name: /cards/i }).click();
@@ -91,7 +91,7 @@ test.describe('Lobby Picker (integration)', () => {
 
   test('swaps between Create new and Join via invitation tabs', async ({ page }) => {
     await page.goto('/lobby');
-    await expect(page.getByText('Add a Lobby')).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator('.naval-card-title', { hasText: 'Add a Lobby' })).toBeVisible({ timeout: 30_000 });
 
     await expect(page.getByPlaceholder(/Lobby name/i)).toBeVisible();
 

--- a/app/e2e/lobby.spec.ts
+++ b/app/e2e/lobby.spec.ts
@@ -44,10 +44,14 @@ test.describe('Lobby (integration)', () => {
   test('exposes the executor key with a copy affordance', async ({ page }) => {
     const env = getEnv();
     await page.goto(`/lobby?id=${encodeURIComponent(env.namespaceId)}`);
-    await expect(page.getByText('Your Key')).toBeVisible({ timeout: 30_000 });
-    // Truncated key uses ellipsis: first 12 chars … last 8.
+    // Scope to the "Your Key" info-pair: the same truncated string also
+    // renders inside the Members list, which would trip strict-mode locators.
+    const yourKeyPair = page.locator('.info-pair', { hasText: 'Your Key' });
+    await expect(yourKeyPair).toBeVisible({ timeout: 30_000 });
     const head = env.node1.memberKey.slice(0, 12);
-    await expect(page.getByText(new RegExp(`^${escapeRegex(head)}\\.\\.\\.`))).toBeVisible();
+    await expect(
+      yourKeyPair.getByText(new RegExp(`^${escapeRegex(head)}\\.\\.\\.`)),
+    ).toBeVisible();
   });
 
   test('renders the New Match form', async ({ page }) => {

--- a/app/e2e/lobby.spec.ts
+++ b/app/e2e/lobby.spec.ts
@@ -7,13 +7,12 @@
 
 import { test, expect } from '@playwright/test';
 import { envAvailable, getEnv } from './helpers/rpc-client';
-import { bypassCors, injectMeroAuth } from './helpers/node-client';
+import { injectMeroAuth } from './helpers/node-client';
 
 test.describe('Lobby (integration)', () => {
   test.beforeEach(async ({ page }) => {
     if (!envAvailable()) test.skip();
     const env = getEnv();
-    await bypassCors(page, [{ nodeUrl: env.node1.url, accessToken: env.node1.accessToken }]);
     await injectMeroAuth(page, {
       nodeUrl: env.node1.url,
       accessToken: env.node1.accessToken,
@@ -65,7 +64,6 @@ test.describe('Lobby Picker (integration)', () => {
   test.beforeEach(async ({ page }) => {
     if (!envAvailable()) test.skip();
     const env = getEnv();
-    await bypassCors(page, [{ nodeUrl: env.node1.url, accessToken: env.node1.accessToken }]);
     await injectMeroAuth(page, {
       nodeUrl: env.node1.url,
       accessToken: env.node1.accessToken,

--- a/app/e2e/match.spec.ts
+++ b/app/e2e/match.spec.ts
@@ -9,7 +9,7 @@
 
 import { test, expect, type BrowserContext, type Page } from '@playwright/test';
 import { envAvailable, getEnv, type NodeEnv } from './helpers/rpc-client';
-import { injectMeroAuth } from './helpers/node-client';
+import { bypassCors } from './helpers/node-client';
 
 const SHIP_PLACEMENTS_P1 = [
   { len: 2, x: 0, y: 0 },
@@ -75,6 +75,9 @@ test.describe('Match (full game playthrough)', () => {
 
     const p1Ctx = await browser.newContext();
     const p2Ctx = await browser.newContext();
+
+    await bypassCors(p1Ctx, env.node1.url, env.node2.url);
+    await bypassCors(p2Ctx, env.node1.url, env.node2.url);
 
     await seedAuth(p1Ctx, env.node1);
     await seedAuth(p2Ctx, env.node2);

--- a/app/e2e/match.spec.ts
+++ b/app/e2e/match.spec.ts
@@ -76,8 +76,11 @@ test.describe('Match (full game playthrough)', () => {
     const p1Ctx = await browser.newContext();
     const p2Ctx = await browser.newContext();
 
-    await bypassCors(p1Ctx, env.node1.url, env.node2.url);
-    await bypassCors(p2Ctx, env.node1.url, env.node2.url);
+    // Each context uses its own node's bearer token. The route handler
+    // re-injects Authorization for outbound requests since Chromium drops
+    // it cross-origin without a fully-successful preflight.
+    await bypassCors(p1Ctx, [{ nodeUrl: env.node1.url, accessToken: env.node1.accessToken }]);
+    await bypassCors(p2Ctx, [{ nodeUrl: env.node2.url, accessToken: env.node2.accessToken }]);
 
     await seedAuth(p1Ctx, env.node1);
     await seedAuth(p2Ctx, env.node2);

--- a/app/e2e/match.spec.ts
+++ b/app/e2e/match.spec.ts
@@ -9,6 +9,7 @@
 
 import { test, expect, type BrowserContext, type Page } from '@playwright/test';
 import { envAvailable, getEnv, type NodeEnv } from './helpers/rpc-client';
+import { injectMeroAuth } from './helpers/node-client';
 
 const SHIP_PLACEMENTS_P1 = [
   { len: 2, x: 0, y: 0 },
@@ -122,17 +123,7 @@ test.describe('Match (full game playthrough)', () => {
 
 async function seedAuth(ctx: BrowserContext, node: NodeEnv): Promise<void> {
   const env = getEnv();
-  await ctx.addInitScript((data) => {
-    const expiresAt = String(Date.now() + 3_600_000);
-    localStorage.setItem('mero:access_token', data.accessToken);
-    localStorage.setItem('mero:refresh_token', data.refreshToken);
-    localStorage.setItem('mero:expires_at', expiresAt);
-    localStorage.setItem('mero:node_url', data.nodeUrl);
-    localStorage.setItem('mero:application_id', data.applicationId);
-    localStorage.setItem('mero:context_id', data.lobbyContextId);
-    localStorage.setItem('mero:context_identity', data.memberKey);
-    localStorage.setItem('battleships:selectedNamespaceId', data.namespaceId);
-  }, {
+  await injectMeroAuth(ctx, {
     nodeUrl: node.url,
     accessToken: node.accessToken,
     refreshToken: node.refreshToken,

--- a/app/e2e/match.spec.ts
+++ b/app/e2e/match.spec.ts
@@ -9,7 +9,6 @@
 
 import { test, expect, type BrowserContext, type Page } from '@playwright/test';
 import { envAvailable, getEnv, type NodeEnv } from './helpers/rpc-client';
-import { bypassCors } from './helpers/node-client';
 
 const SHIP_PLACEMENTS_P1 = [
   { len: 2, x: 0, y: 0 },
@@ -75,12 +74,6 @@ test.describe('Match (full game playthrough)', () => {
 
     const p1Ctx = await browser.newContext();
     const p2Ctx = await browser.newContext();
-
-    // Each context uses its own node's bearer token. The route handler
-    // re-injects Authorization for outbound requests since Chromium drops
-    // it cross-origin without a fully-successful preflight.
-    await bypassCors(p1Ctx, [{ nodeUrl: env.node1.url, accessToken: env.node1.accessToken }]);
-    await bypassCors(p2Ctx, [{ nodeUrl: env.node2.url, accessToken: env.node2.accessToken }]);
 
     await seedAuth(p1Ctx, env.node1);
     await seedAuth(p2Ctx, env.node2);

--- a/app/e2e/match.spec.ts
+++ b/app/e2e/match.spec.ts
@@ -1,0 +1,215 @@
+/**
+ * Two-player full-game playthrough against live merod nodes.
+ *
+ * Drives the entire battleships flow through the UI in two isolated browser
+ * contexts — one authed against node-1 (P1), one against node-2 (P2).
+ * P1 challenges P2 from the lobby, both deploy fleets, then 33 turns are
+ * played from a deterministic shot script that ends with P1 winning.
+ */
+
+import { test, expect, type BrowserContext, type Page } from '@playwright/test';
+import { envAvailable, getEnv, type NodeEnv } from './helpers/rpc-client';
+import { injectMeroAuth } from './helpers/node-client';
+
+const SHIP_PLACEMENTS_P1 = [
+  { len: 2, x: 0, y: 0 },
+  { len: 3, x: 0, y: 2 },
+  { len: 3, x: 0, y: 4 },
+  { len: 4, x: 0, y: 6 },
+  { len: 5, x: 0, y: 8 },
+] as const;
+
+const SHIP_PLACEMENTS_P2 = [
+  { len: 2, x: 8, y: 0 },
+  { len: 3, x: 7, y: 2 },
+  { len: 3, x: 7, y: 4 },
+  { len: 4, x: 6, y: 6 },
+  { len: 5, x: 5, y: 8 },
+] as const;
+
+type Turn = { player: 'p1' | 'p2'; x: number; y: number };
+
+const TURNS: Turn[] = [
+  { player: 'p1', x: 8, y: 0 }, // 1
+  { player: 'p2', x: 0, y: 0 }, // 2
+  { player: 'p1', x: 9, y: 0 }, // 3
+  { player: 'p2', x: 1, y: 0 }, // 4
+  { player: 'p1', x: 5, y: 8 }, // 5
+  { player: 'p2', x: 5, y: 5 }, // 6 miss
+  { player: 'p1', x: 7, y: 2 }, // 7
+  { player: 'p2', x: 0, y: 2 }, // 8
+  { player: 'p1', x: 6, y: 8 }, // 9
+  { player: 'p2', x: 3, y: 3 }, // 10 miss
+  { player: 'p1', x: 7, y: 4 }, // 11
+  { player: 'p2', x: 1, y: 2 }, // 12
+  { player: 'p1', x: 8, y: 2 }, // 13
+  { player: 'p2', x: 2, y: 2 }, // 14
+  { player: 'p1', x: 9, y: 2 }, // 15
+  { player: 'p2', x: 5, y: 3 }, // 16 miss
+  { player: 'p1', x: 6, y: 6 }, // 17
+  { player: 'p2', x: 0, y: 4 }, // 18
+  { player: 'p1', x: 7, y: 8 }, // 19
+  { player: 'p2', x: 1, y: 4 }, // 20
+  { player: 'p1', x: 8, y: 4 }, // 21
+  { player: 'p2', x: 7, y: 7 }, // 22 miss
+  { player: 'p1', x: 7, y: 6 }, // 23
+  { player: 'p2', x: 0, y: 6 }, // 24
+  { player: 'p1', x: 8, y: 6 }, // 25
+  { player: 'p2', x: 1, y: 6 }, // 26
+  { player: 'p1', x: 9, y: 4 }, // 27
+  { player: 'p2', x: 9, y: 9 }, // 28 miss
+  { player: 'p1', x: 8, y: 8 }, // 29
+  { player: 'p2', x: 0, y: 8 }, // 30
+  { player: 'p1', x: 9, y: 6 }, // 31
+  { player: 'p2', x: 1, y: 8 }, // 32
+  { player: 'p1', x: 9, y: 8 }, // 33 — P1 winning hit
+];
+
+test.describe('Match (full game playthrough)', () => {
+  test.skip(!envAvailable(), 'integration env not available');
+
+  test('two players play a complete game and P1 wins', async ({ browser }) => {
+    test.setTimeout(300_000);
+
+    const env = getEnv();
+
+    const p1Ctx = await browser.newContext();
+    const p2Ctx = await browser.newContext();
+
+    await seedAuth(p1Ctx, env.node1);
+    await seedAuth(p2Ctx, env.node2);
+
+    const p1 = await p1Ctx.newPage();
+    const p2 = await p2Ctx.newPage();
+
+    try {
+      await openLobby(p1, env.namespaceId);
+      await openLobby(p2, env.namespaceId);
+
+      await expect(p1.getByText(/2 members online/i)).toBeVisible({ timeout: 30_000 });
+      await expect(p2.getByText(/2 members online/i)).toBeVisible({ timeout: 30_000 });
+
+      await challengeOpponent(p1, env.node2.memberKey);
+
+      await openMatchOnP2(p2);
+
+      await waitForGameView(p1);
+      await waitForGameView(p2);
+
+      await placeFleet(p1, SHIP_PLACEMENTS_P1);
+      await placeFleet(p2, SHIP_PLACEMENTS_P2);
+
+      await waitForBoardsReady(p1);
+      await waitForBoardsReady(p2);
+
+      for (const turn of TURNS) {
+        const actor = turn.player === 'p1' ? p1 : p2;
+        await waitForMyTurn(actor);
+        await fireShot(actor, turn.x, turn.y);
+      }
+
+      await expect(p1.getByText('🏆 You won this match.')).toBeVisible({ timeout: 60_000 });
+      await expect(p1.getByText('Victory')).toBeVisible();
+      await expect(p2.getByText('Match over.')).toBeVisible({ timeout: 60_000 });
+      await expect(p2.getByText('Defeat')).toBeVisible();
+    } finally {
+      await p1Ctx.close();
+      await p2Ctx.close();
+    }
+  });
+});
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+async function seedAuth(ctx: BrowserContext, node: NodeEnv): Promise<void> {
+  const env = getEnv();
+  await ctx.addInitScript((data) => {
+    const expiresAt = String(Date.now() + 3_600_000);
+    localStorage.setItem('mero:access_token', data.accessToken);
+    localStorage.setItem('mero:refresh_token', data.refreshToken);
+    localStorage.setItem('mero:expires_at', expiresAt);
+    localStorage.setItem('mero:node_url', data.nodeUrl);
+    localStorage.setItem('mero:application_id', data.applicationId);
+    localStorage.setItem('mero:context_id', data.lobbyContextId);
+    localStorage.setItem('mero:context_identity', data.memberKey);
+    localStorage.setItem('battleships:selectedNamespaceId', data.namespaceId);
+  }, {
+    nodeUrl: node.url,
+    accessToken: node.accessToken,
+    refreshToken: node.refreshToken,
+    memberKey: node.memberKey,
+    applicationId: env.applicationId,
+    lobbyContextId: env.lobbyContextId,
+    namespaceId: env.namespaceId,
+  });
+}
+
+async function openLobby(page: Page, namespaceId: string): Promise<void> {
+  await page.goto(`/lobby?id=${encodeURIComponent(namespaceId)}`);
+  await expect(page.getByText('Lobby').first()).toBeVisible({ timeout: 60_000 });
+}
+
+async function challengeOpponent(p1: Page, opponentKey: string): Promise<void> {
+  const input = p1.getByPlaceholder(/Opponent's executor public key/i);
+  await input.fill(opponentKey);
+  await p1.getByRole('button', { name: 'Challenge' }).click();
+}
+
+async function openMatchOnP2(p2: Page): Promise<void> {
+  // The Open button only renders once MatchListUpdated/MatchCreated has
+  // synced from node-1 and the match has status=Active with a context_id.
+  const openButton = p2.getByRole('button', { name: 'Open' }).first();
+  await openButton.waitFor({ timeout: 90_000 });
+  await openButton.click();
+}
+
+async function waitForGameView(page: Page): Promise<void> {
+  await page.waitForURL(/\/match\?/, { timeout: 60_000 });
+  // matchApiReady gates Deploy Fleet; this loader card appears while we wait.
+  await expect(
+    page.getByText('Deploy Fleet').or(page.getByText('Joining match…')),
+  ).toBeVisible({ timeout: 60_000 });
+}
+
+async function placeFleet(
+  page: Page,
+  placements: ReadonlyArray<{ len: number; x: number; y: number }>,
+): Promise<void> {
+  // Wait out the joiner-side sync loader before clicking the placement grid.
+  await page.locator('.placement-grid').waitFor({ timeout: 60_000 });
+
+  let lastSelectedLen: number | null = null;
+  for (const ship of placements) {
+    if (ship.len !== lastSelectedLen) {
+      await page.locator(`.ship-btn[data-ship-len="${ship.len}"]`).click();
+      lastSelectedLen = ship.len;
+    }
+    await page
+      .locator(`.placement-grid .cell[data-x="${ship.x}"][data-y="${ship.y}"]`)
+      .click();
+  }
+
+  const deploy = page.getByRole('button', { name: 'Deploy Fleet' });
+  await expect(deploy).toBeEnabled({ timeout: 5_000 });
+  await deploy.click();
+}
+
+async function waitForBoardsReady(page: Page): Promise<void> {
+  await page.locator('.shot-grid').waitFor({ timeout: 60_000 });
+  await expect(page.getByText('Your Waters')).toBeVisible();
+}
+
+async function waitForMyTurn(page: Page): Promise<void> {
+  // The shot grid only renders .cell-clickable cells when isMyTurn === true.
+  await page.locator('.shot-grid .cell-clickable').first().waitFor({ timeout: 60_000 });
+}
+
+async function fireShot(page: Page, x: number, y: number): Promise<void> {
+  const cell = page.locator(`.shot-grid .cell[data-x="${x}"][data-y="${y}"]`);
+  await expect(cell).toHaveClass(/cell-clickable/, { timeout: 30_000 });
+  await cell.click();
+  await page.getByRole('button', { name: 'Fire' }).click();
+
+  // Pending → resolved (hit or miss) within sync timeout.
+  await expect(cell).toHaveClass(/cell-(hit|miss)/, { timeout: 30_000 });
+}

--- a/app/e2e/match.spec.ts
+++ b/app/e2e/match.spec.ts
@@ -112,6 +112,18 @@ test.describe('Match (full game playthrough)', () => {
       await expect(p1.getByText('Victory')).toBeVisible();
       await expect(p2.getByText('Match over.')).toBeVisible({ timeout: 60_000 });
       await expect(p2.getByText('Defeat')).toBeVisible();
+
+      // Post-match state on both pages: navigate back via the in-game button
+      // (user-realistic), then assert that the lobby's Your Record card and
+      // Match History card reflect the just-completed match. Generous timeouts
+      // because the loser's node has to receive the match-finished delta.
+      await p1.getByRole('button', { name: 'Back to Lobby' }).click();
+      await p2.getByRole('button', { name: 'Back to Lobby' }).click();
+
+      await expectPostMatchRecord(p1, 'winner');
+      await expectPostMatchRecord(p2, 'loser');
+      await expectPostMatchHistory(p1, 'winner');
+      await expectPostMatchHistory(p2, 'loser');
     } finally {
       await p1Ctx.close();
       await p2Ctx.close();
@@ -205,4 +217,29 @@ async function fireShot(page: Page, x: number, y: number): Promise<void> {
 
   // Pending → resolved (hit or miss) within sync timeout.
   await expect(cell).toHaveClass(/cell-(hit|miss)/, { timeout: 30_000 });
+}
+
+async function expectPostMatchRecord(page: Page, role: 'winner' | 'loser'): Promise<void> {
+  const card = page.locator('.naval-card', {
+    has: page.locator('.naval-card-title', { hasText: 'Your Record' }),
+  });
+  await expect(card).toBeVisible({ timeout: 60_000 });
+  const wins = role === 'winner' ? '1' : '0';
+  const losses = role === 'winner' ? '0' : '1';
+  await expect(card.locator('.info-pair', { hasText: 'Wins' }).locator('.info-value'))
+    .toHaveText(wins, { timeout: 60_000 });
+  await expect(card.locator('.info-pair', { hasText: 'Losses' }).locator('.info-value'))
+    .toHaveText(losses);
+  await expect(card.locator('.info-pair', { hasText: 'Games' }).locator('.info-value'))
+    .toHaveText('1');
+}
+
+async function expectPostMatchHistory(page: Page, role: 'winner' | 'loser'): Promise<void> {
+  const card = page.locator('.naval-card', {
+    has: page.locator('.naval-card-title', { hasText: 'Match History' }),
+  });
+  await expect(card).toBeVisible({ timeout: 60_000 });
+  await expect(card.locator('.match-item').first()).toBeVisible({ timeout: 60_000 });
+  const expectedLabel = role === 'winner' ? 'You won' : 'You lost';
+  await expect(card.locator('.match-item').first().getByText(expectedLabel)).toBeVisible();
 }

--- a/app/e2e/match.spec.ts
+++ b/app/e2e/match.spec.ts
@@ -156,8 +156,11 @@ async function openMatchOnP2(p2: Page): Promise<void> {
 async function waitForGameView(page: Page): Promise<void> {
   await page.waitForURL(/\/match\?/, { timeout: 60_000 });
   // matchApiReady gates Deploy Fleet; this loader card appears while we wait.
+  // 'Deploy Fleet' appears in both the card title and the button — scope to
+  // the title to disambiguate.
   await expect(
-    page.getByText('Deploy Fleet').or(page.getByText('Joining match…')),
+    page.locator('.naval-card-title', { hasText: 'Deploy Fleet' })
+      .or(page.getByText('Joining match…')),
   ).toBeVisible({ timeout: 60_000 });
 }
 

--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@calimero-network/abi-codegen": "^1.0.2",
     "@eslint/js": "^9.4.0",
+    "@playwright/test": "^1.52.0",
     "@types/eslint__js": "^8.42.3",
     "@types/node": "^16.18.98",
     "@types/react": "^19.0.0",
@@ -53,12 +54,18 @@
     "predeploy": "pnpm run build",
     "deploy": "gh-pages -d build",
     "prettier": "exec prettier . --write",
-    "test": "vitest run"
+    "test": "vitest run",
+    "e2e:landing": "playwright test --project=landing",
+    "e2e:integration": "playwright test --project=integration",
+    "e2e:report": "playwright show-report playwright-report"
   },
   "eslintConfig": {
     "extends": [
       "react-app",
       "react-app/jest"
+    ],
+    "ignorePatterns": [
+      "e2e/**"
     ]
   },
   "browserslist": {

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -49,6 +49,18 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
         storageState: { cookies: [], origins: [] },
         trace: 'on',
+        // Traefik's forward-auth middleware rejects OPTIONS preflight (no
+        // Authorization header by browser-spec), which strips CORS headers
+        // and blocks every cross-origin admin-api fetch from localhost:5173.
+        // Disabling web security in the test browser bypasses the preflight.
+        // Production code paths are unaffected — same-origin deployments
+        // don't see this preflight in the first place.
+        launchOptions: {
+          args: [
+            '--disable-web-security',
+            '--disable-site-isolation-trials',
+          ],
+        },
       },
     },
   ],

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -48,19 +48,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         storageState: { cookies: [], origins: [] },
-        trace: 'on',
-        // Traefik's forward-auth middleware rejects OPTIONS preflight (no
-        // Authorization header by browser-spec), which strips CORS headers
-        // and blocks every cross-origin admin-api fetch from localhost:5173.
-        // Disabling web security in the test browser bypasses the preflight.
-        // Production code paths are unaffected — same-origin deployments
-        // don't see this preflight in the first place.
-        launchOptions: {
-          args: [
-            '--disable-web-security',
-            '--disable-site-isolation-trials',
-          ],
-        },
+        trace: 'retain-on-failure',
       },
     },
   ],

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const APP_URL = process.env.VITE_APP_URL ?? 'http://localhost:5173';
+
+export default defineConfig({
+  testDir: './e2e',
+  globalSetup: './e2e/global-setup.ts',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  timeout: 60_000,
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: 'playwright-report' }],
+  ],
+  use: {
+    baseURL: APP_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+  },
+  webServer: process.env.SKIP_WEB_SERVER
+    ? undefined
+    : {
+        command: 'pnpm dev --host 127.0.0.1 --port 5173',
+        url: APP_URL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+  projects: [
+    {
+      name: 'landing',
+      testMatch: ['**/landing.spec.ts'],
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: { cookies: [], origins: [] },
+      },
+    },
+    {
+      name: 'integration',
+      testMatch: ['**/lobby.spec.ts', '**/match.spec.ts'],
+      timeout: 300_000,
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: { cookies: [], origins: [] },
+      },
+    },
+  ],
+});

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -43,11 +43,12 @@ export default defineConfig({
     },
     {
       name: 'integration',
-      testMatch: ['**/lobby.spec.ts', '**/match.spec.ts'],
+      testMatch: ['**/diagnostics.spec.ts', '**/lobby.spec.ts', '**/match.spec.ts'],
       timeout: 300_000,
       use: {
         ...devices['Desktop Chrome'],
         storageState: { cookies: [], origins: [] },
+        trace: 'on',
       },
     },
   ],

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@eslint/js':
         specifier: ^9.4.0
         version: 9.36.0
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.59.1
       '@types/eslint__js':
         specifier: ^8.42.3
         version: 8.42.3
@@ -1039,6 +1042,11 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
@@ -2322,6 +2330,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2918,6 +2931,16 @@ packages:
   pkg-dir@5.0.0:
     resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
     engines: {node: '>=10'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4712,6 +4735,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@remirror/core-constants@3.0.0': {}
 
   '@remix-run/router@1.23.0': {}
@@ -6316,6 +6343,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6961,6 +6991,14 @@ snapshots:
   pkg-dir@5.0.0:
     dependencies:
       find-up: 5.0.0
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/app/src/components/GameBoard.tsx
+++ b/app/src/components/GameBoard.tsx
@@ -29,7 +29,7 @@ export default function GameBoard({ size, board, label, pendingShot }: GameBoard
   };
 
   return (
-    <div className="board-container">
+    <div className="board-container game-board">
       <div className="board-label">{label}</div>
       <div className="board-grid-wrapper">
         <div className="coord-row">
@@ -42,7 +42,7 @@ export default function GameBoard({ size, board, label, pendingShot }: GameBoard
             <div className="row-label">{y + 1}</div>
             {Array.from({ length: size }, (_, x) => {
               const val = board[y * size + x] || 0;
-              return <div key={`${x}-${y}`} className={cellClass(val, x, y)} />;
+              return <div key={`${x}-${y}`} data-x={x} data-y={y} className={cellClass(val, x, y)} />;
             })}
           </div>
         ))}

--- a/app/src/components/PlacementGrid.tsx
+++ b/app/src/components/PlacementGrid.tsx
@@ -13,7 +13,7 @@ interface PlacementGridProps {
  */
 export default function PlacementGrid({ size, grid, onCellClick }: PlacementGridProps) {
   return (
-    <div className="board-container">
+    <div className="board-container placement-grid">
       <div className="board-label">Place Your Fleet</div>
       <div className="board-grid-wrapper">
         <div className="coord-row">
@@ -27,6 +27,8 @@ export default function PlacementGrid({ size, grid, onCellClick }: PlacementGrid
             {Array.from({ length: size }, (_, x) => (
               <div
                 key={`${x}-${y}`}
+                data-x={x}
+                data-y={y}
                 className={`cell cell-editable ${grid[y][x] ? 'cell-ship' : 'cell-empty'}`}
                 onClick={() => onCellClick(x, y)}
               />

--- a/app/src/components/ShipSelector.tsx
+++ b/app/src/components/ShipSelector.tsx
@@ -29,6 +29,7 @@ export default function ShipSelector({
           return (
             <button
               key={len}
+              data-ship-len={len}
               className={`ship-btn ${active ? 'ship-btn-active' : ''}`}
               disabled={full}
               onClick={() => onSelectShip(active ? null : idx)}

--- a/app/src/components/ShotGrid.tsx
+++ b/app/src/components/ShotGrid.tsx
@@ -31,7 +31,7 @@ export default function ShotGrid({
   };
 
   return (
-    <div className="board-container">
+    <div className="board-container shot-grid">
       <div className="board-label">
         Shots Fired
         {isMyTurn && (
@@ -62,6 +62,8 @@ export default function ShotGrid({
               return (
                 <div
                   key={`${x}-${y}`}
+                  data-x={x}
+                  data-y={y}
                   className={cellClass(val, x, y)}
                   onClick={() => clickable && onCellClick(x, y)}
                 />

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -1,13 +1,19 @@
+/// <reference types="vitest" />
 import { defineConfig } from 'vite';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 
-// https://vitejs.dev/config/
 export default defineConfig({
   base: '/',
   build: {
     outDir: 'build',
   },
   plugins: [nodePolyfills(), react()],
+  test: {
+    // Playwright specs in e2e/ run under `playwright test`, not vitest,
+    // and would crash here. Keep vitest scoped to src.
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: ['node_modules', 'build', 'e2e'],
+  },
 });

--- a/e2e/workflow-battleships-integration-setup.yml
+++ b/e2e/workflow-battleships-integration-setup.yml
@@ -11,12 +11,12 @@ description: >
 
 force_pull_image: true
 
-# auth_service intentionally OFF: with the Traefik auth-service stack
-# enabled, /admin-api goes through forward-auth middleware whose OPTIONS
-# preflight handling kills cross-origin browser fetches. Without it,
-# merod's admin API is reachable directly on localhost:2528/2529 with
-# wildcard CORS and no JWT required, which is what the Playwright tests
-# need.
+# Auth-service ON: nodes are reached at http://nodeN.127.0.0.1.nip.io
+# through Traefik. Browsers from a different origin (Vite at :5173)
+# need merobox >=0.6.9 so that OPTIONS preflights bypass forward-auth
+# (calimero-network/merobox#228).
+
+auth_service: true
 
 nodes:
   count: 2

--- a/e2e/workflow-battleships-integration-setup.yml
+++ b/e2e/workflow-battleships-integration-setup.yml
@@ -11,10 +11,12 @@ description: >
 
 force_pull_image: true
 
-# Enable the Traefik auth-service proxy so the runner (and Chromium) can
-# reach the admin/RPC API at http://nodeN.127.0.0.1.nip.io and mint JWTs
-# via /auth/token. Without this the admin port is only docker-internal.
-auth_service: true
+# auth_service intentionally OFF: with the Traefik auth-service stack
+# enabled, /admin-api goes through forward-auth middleware whose OPTIONS
+# preflight handling kills cross-origin browser fetches. Without it,
+# merod's admin API is reachable directly on localhost:2528/2529 with
+# wildcard CORS and no JWT required, which is what the Playwright tests
+# need.
 
 nodes:
   count: 2

--- a/e2e/workflow-battleships-integration-setup.yml
+++ b/e2e/workflow-battleships-integration-setup.yml
@@ -11,6 +11,11 @@ description: >
 
 force_pull_image: true
 
+# Enable the Traefik auth-service proxy so the runner (and Chromium) can
+# reach the admin/RPC API at http://nodeN.127.0.0.1.nip.io and mint JWTs
+# via /auth/token. Without this the admin port is only docker-internal.
+auth_service: true
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge

--- a/e2e/workflow-battleships-integration-setup.yml
+++ b/e2e/workflow-battleships-integration-setup.yml
@@ -1,0 +1,93 @@
+name: Battleships Integration Setup — Namespace + Lobby + Two Members
+description: >
+  Slim merobox setup for Playwright integration tests.
+  Brings up two nodes, installs the battleships app, creates a namespace and
+  lobby context on node-1, and joins node-2 via a namespace invitation.
+  Stops short of match creation — Playwright drives matches and gameplay
+  through the UI.
+
+  stop_all_nodes: false keeps the merod containers alive after merobox exits
+  so the Playwright job can reach the admin/RPC API on each node.
+
+force_pull_image: true
+
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: calimero-node
+
+steps:
+  - name: Install Battleships App on Node 1
+    type: install_application
+    node: calimero-node-1
+    path: ../logic/res/battleships-0.3.0.mpk
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create Namespace on Node 1
+    type: create_namespace
+    node: calimero-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create Lobby Context in Namespace
+    type: create_context
+    node: calimero-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    service_name: lobby
+    outputs:
+      lobby_ctx_id: contextId
+      p1_key: memberPublicKey
+
+  - name: Assert Lobby Context Created
+    type: assert
+    statements:
+      - 'is_set({{lobby_ctx_id}})'
+      - 'is_set({{p1_key}})'
+
+  - name: Create Namespace Invitation
+    type: create_namespace_invitation
+    node: calimero-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invitation: invitation
+
+  - name: Wait for Namespace Gossip Propagation
+    type: wait
+    seconds: 10
+    message: Waiting for namespace gossip to reach node 2
+
+  - name: Node 2 Joins Namespace
+    type: join_namespace
+    node: calimero-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invitation}}'
+    outputs:
+      p2_identity: memberIdentity
+
+  - name: Node 2 Joins Lobby Context
+    type: join_context
+    node: calimero-node-2
+    context_id: '{{lobby_ctx_id}}'
+    outputs:
+      lobby_ctx_id_node2: contextId
+      p2_key: memberPublicKey
+
+  - name: Assert Node 2 Joined
+    type: assert
+    statements:
+      - 'is_set({{p2_key}})'
+      - 'is_set({{p2_identity}})'
+
+  - name: Wait for Lobby Sync
+    type: wait_for_sync
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    context_id: '{{lobby_ctx_id}}'
+    timeout: 30
+
+stop_all_nodes: false


### PR DESCRIPTION
## Summary

Adds a full-stack browser integration test job: builds the WASM bundle, spins up two merod nodes via merobox, mints JWTs and seeds a namespace + lobby + two members, then drives the entire battleships flow through Chromium in two isolated browser contexts.

- **Slim merobox setup** (`e2e/workflow-battleships-integration-setup.yml`) — phase-A only (install → namespace → lobby → join → sync), `stop_all_nodes: false` so the merod containers stay alive while Playwright runs.
- **Two Playwright projects** (`app/playwright.config.ts`):
  - `landing` — unauth surface; runs against `pnpm dev`, no live node.
  - `integration` — needs `app/.env.integration`; skips gracefully when absent.
- **3 spec files**:
  - `landing.spec.ts` — 7 tests: title, branding, ConnectButton, external links, route guards.
  - `lobby.spec.ts` — 7 tests: lobby renders with both members online, members list, executor key copy, New Match form, lobby picker (Add a Lobby tabs swap, list/cards toggle, info-icon a11y).
  - `match.spec.ts` — full game playthrough. Two `BrowserContext`s (P1 → node-1, P2 → node-2). P1 challenges P2 from the lobby, both deploy fleets via the placement grid, then 33 turns are played from a deterministic shot script that ends with P1 winning. Asserts `🏆 You won this match.` + `Victory` / `Defeat` badges.
- **CI workflow** (`.github/workflows/integration-ci.yml`):
  1. Build bundle against current core master (Cargo.lock gitignored).
  2. Install merobox via apt.
  3. Run setup workflow with live log-watcher.
  4. Mint tokens via `/auth/token` against both nodes; discover application/namespace/context/member IDs via `/admin-api`; write `app/.env.integration`.
  5. Install pnpm + Playwright Chromium.
  6. `pnpm exec playwright test --project=integration` with `INTEGRATION_MODE=true`.
  7. Cleanup; upload `playwright-report/`, traces on failure, and merod docker logs.
- **Minimal UI hooks** for selector robustness — `data-x`/`data-y` on board cells, `data-ship-len` on ship-selector buttons, scoped `placement-grid` / `shot-grid` / `game-board` wrapper classes. No behavior change.
- **vitest scoped to `src/**`** so `pnpm test` doesn't try to execute Playwright specs.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` (vitest, 36 tests) — green
- [x] `pnpm build` — green
- [x] `playwright test --list` — 15 tests across 2 projects
- [ ] CI: Integration Tests (Browser) job passes against live nodes
- [ ] Confirm Playwright HTML report uploaded as artifact on green + failed runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new end-to-end CI workflow that boots Dockerized `merod` nodes, mints auth tokens, and runs long-running Playwright tests, which increases CI complexity and potential flakiness/timeouts. Product code changes are minimal (test selectors/data attributes) but the pipeline relies on external services/images and coordination between multiple processes.
> 
> **Overview**
> Adds a new **GitHub Actions browser integration job** (`integration-ci.yml`) that builds the WASM bundle, provisions two `merod` nodes via merobox, bootstraps auth (minting JWTs + discovering seeded IDs), writes `app/.env.integration`, then runs Playwright’s `integration` project and uploads reports/traces/docker logs.
> 
> Introduces a **Playwright test harness** in `app/` (config + global setup + env/auth helpers) plus new specs for unauthenticated landing coverage and live-node flows, including a two-context end-to-end match playthrough.
> 
> Makes **small UI selector-only tweaks** (adds `data-x`/`data-y`, `data-ship-len`, and grid wrapper classes) and updates tooling (`@playwright/test` dependency, new `e2e:*` scripts, vitest scoping, `.gitignore` entries) to support the new E2E setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cef15c7e3ed0301835e87c154ed7d1c39e0842f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->