### PR TITLE
ci: add AI code review and doc auto-update workflows

### DIFF
--- a/.ai-reviewer.yaml
+++ b/.ai-reviewer.yaml
@@ -1,0 +1,16 @@
+version: 1
+
+anthropic:
+  default_model: claude-sonnet-4-6
+  enable_prompt_caching: true
+
+doc_generation:
+  enabled: true
+  model: claude-haiku-4-5-20251001
+  max_files: 10
+  static_docs_dirs:
+    - architecture/
+  pr_labels:
+    - automated-docs
+    - documentation
+  pr_draft: true

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -1,0 +1,79 @@
+name: AI Code Review
+
+on:
+  pull_request:
+    # `synchronize` omitted — review fires on PR open/reopen/draft→ready, not each push.
+    # Re-trigger via toggling draft or workflow_dispatch.
+    types: [opened, reopened, ready_for_review]
+    # Pure-doc PRs are owned by Doc Auto-Update; skip to avoid paying twice.
+    paths-ignore:
+      - 'docs/**'
+      - 'architecture/**'
+      - 'docs-static/**'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: number
+      agents:
+        description: "Number of agents (1-5)"
+        required: false
+        default: "3"
+        type: choice
+        options: ["1", "2", "3", "4", "5"]
+
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    # Skip on draft PRs and fork PRs (forks don't get repo secrets).
+    # Maintainers can review fork PRs manually via workflow_dispatch.
+    if: >-
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # Pinned SHA — bump deliberately when adopting new reviewer features.
+      - name: Install ai-code-reviewer
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@713c5b1251132dd93b6ec70889e336dad3c09402
+
+      - name: Determine PR number and agent count
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "agents=${{ github.event.inputs.agents }}"    >> $GITHUB_OUTPUT
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            # Default to 1 agent for cost; bump via workflow_dispatch when needed.
+            echo "agents=1"                                        >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run AI Code Review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          ai-reviewer review-pr \
+            ${{ github.repository }} \
+            ${{ steps.pr.outputs.number }} \
+            --agents ${{ steps.pr.outputs.agents }} \
+            --reviewer-name "MeroReviewer" \
+            --output github

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -1,0 +1,82 @@
+name: Doc Auto-Update
+
+on:
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to generate docs for (leave blank to auto-detect)"
+        type: string
+        required: false
+      dry_run:
+        description: "Dry run: print changes without opening a PR"
+        type: boolean
+        default: false
+
+concurrency:
+  group: doc-update-${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # Pinned SHA — bump deliberately when adopting new reviewer features.
+      - name: Install ai-code-reviewer
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@713c5b1251132dd93b6ec70889e336dad3c09402
+
+      - name: Get merged PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          PR_NUM=""
+          if [[ "$INPUT_PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            PR_NUM="$INPUT_PR_NUMBER"
+          fi
+
+          if [ -z "$PR_NUM" ]; then
+            if ! PR_NUM=$(gh api "/repos/$REPO/commits/$SHA/pulls" --jq '.[0].number // empty'); then
+              echo "::warning::gh api commits/{sha}/pulls failed; doc update will be skipped"
+              PR_NUM=""
+            fi
+          fi
+
+          if [[ ! "$PR_NUM" =~ ^[0-9]+$ ]]; then
+            PR_NUM=""
+          fi
+
+          echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
+
+      - name: Generate and open doc update PR
+        if: steps.pr.outputs.number != ''
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          DRY_RUN_FLAG=()
+          if [ "$DRY_RUN" = "true" ]; then
+            DRY_RUN_FLAG=(--dry-run)
+          fi
+          ai-reviewer update-docs "$REPO" "$PR_NUMBER" "${DRY_RUN_FLAG[@]}"
+
+      - name: No PR detected
+        if: steps.pr.outputs.number == ''
+        run: echo "Could not detect a merged PR — skipping doc update."


### PR DESCRIPTION
Adds AI code review (MeroReviewer) and doc auto-update workflows. Pins ai-code-reviewer to SHA `713c5b1`, removes `synchronize` trigger for cost control, adds fork guard, defaults to 1 review agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new GitHub Actions that use repo secrets and write PR comments/branches; misconfiguration could spam PRs or leak tokens via logs, though changes are isolated to CI config.
> 
> **Overview**
> Adds `.ai-reviewer.yaml` to configure Anthropic models and enable automated doc generation that opens *draft*, labeled PRs.
> 
> Introduces a new `AI Code Review` GitHub Action that runs on PR open/reopen/ready events (and manually via `workflow_dispatch`), skips doc-only changes, blocks fork/draft runs, and posts review output to GitHub using a pinned `ai-code-reviewer` SHA.
> 
> Adds a `Doc Auto-Update` workflow that runs on pushes to `main`/`master` (or manually), detects the merged PR for the commit, and invokes `ai-reviewer update-docs` to open a follow-up docs PR (with optional `--dry-run`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa4222b8777a966727aa8cd79b14f83d3db958f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->